### PR TITLE
feat(game): core domain types & state engine (#25)

### DIFF
--- a/__tests__/game/state.test.ts
+++ b/__tests__/game/state.test.ts
@@ -1,0 +1,54 @@
+import { initializeGame, applyAction, createEmptyBoard, getCell } from '../../app/game/state';
+import { isSolved } from '../../app/game/rules';
+import type { Digit, GameConfig } from '../../app/game/types';
+
+const easyConfig: GameConfig = { difficulty: 'easy', maxLives: 3 };
+
+describe('Game state engine', () => {
+	it('initializes with givens and config', () => {
+		const givens = [{ row: 0, col: 0, value: 5 as Digit }];
+		const state = initializeGame(givens, easyConfig);
+		expect(getCell(state.board, 0, 0).value).toBe(5);
+		expect(getCell(state.board, 0, 0).isGiven).toBe(true);
+		expect(state.config.difficulty).toBe('easy');
+		expect(state.livesRemaining).toBe(3);
+	});
+
+	it('applies place, note, and erase deterministically', () => {
+		const state = initializeGame([], easyConfig);
+		let next = applyAction(state, { type: 'place', row: 1, col: 1, value: 7 });
+		expect(getCell(next.board, 1, 1).value).toBe(7);
+		next = applyAction(next, { type: 'note', row: 1, col: 1, value: 3, present: true });
+		expect(getCell(next.board, 1, 1).value).toBe(null);
+		expect(getCell(next.board, 1, 1).notes[3]).toBe(true);
+		next = applyAction(next, { type: 'erase', row: 1, col: 1 });
+		expect(getCell(next.board, 1, 1).value).toBe(null);
+		expect(Object.keys(getCell(next.board, 1, 1).notes).length).toBe(0);
+	});
+
+	it('isSolved returns true for a solved board', () => {
+		const solved = createEmptyBoard();
+		// Populate solved board with a known correct Sudoku solution
+		const rows: number[][] = [
+			[5,3,4,6,7,8,9,1,2],
+			[6,7,2,1,9,5,3,4,8],
+			[1,9,8,3,4,2,5,6,7],
+			[8,5,9,7,6,1,4,2,3],
+			[4,2,6,8,5,3,7,9,1],
+			[7,1,3,9,2,4,8,5,6],
+			[9,6,1,5,3,7,2,8,4],
+			[2,8,7,4,1,9,6,3,5],
+			[3,4,5,2,8,6,1,7,9],
+		];
+		for (let r = 0; r < 9; r++) {
+			const rowVals = rows[r]!;
+			for (let c = 0; c < 9; c++) {
+				getCell(solved, r, c).value = rowVals[c]! as Digit;
+			}
+		}
+		expect(isSolved(solved)).toBe(true);
+	});
+});
+
+
+

--- a/app/game/rules.ts
+++ b/app/game/rules.ts
@@ -1,0 +1,36 @@
+import type { Board } from "./types";
+import { getCell } from "./state";
+
+export function isSolved(board: Board): boolean {
+	// All cells filled and each row/col/box contains digits 1..9 with no repeats
+	for (let r = 0; r < 9; r++) {
+		for (let c = 0; c < 9; c++) {
+			if (!getCell(board, r, c).value) return false;
+		}
+	}
+	const setEquals = (arr: number[]) => arr.slice().sort().join(",") === "1,2,3,4,5,6,7,8,9";
+	for (let r = 0; r < 9; r++) {
+		const row = board[r];
+		if (!row) return false;
+		if (!setEquals(row.map((c) => c.value as number))) return false;
+	}
+	for (let c = 0; c < 9; c++) {
+		const col: number[] = [];
+		for (let r = 0; r < 9; r++) col.push(getCell(board, r, c).value as number);
+		if (!setEquals(col)) return false;
+	}
+	for (let br = 0; br < 3; br++) {
+		for (let bc = 0; bc < 3; bc++) {
+			const box: number[] = [];
+			for (let r = br * 3; r < br * 3 + 3; r++) {
+				for (let c = bc * 3; c < bc * 3 + 3; c++) {
+					box.push(getCell(board, r, c).value as number);
+				}
+			}
+			if (!setEquals(box)) return false;
+		}
+	}
+	return true;
+}
+
+

--- a/app/game/state.ts
+++ b/app/game/state.ts
@@ -1,0 +1,76 @@
+import type { Board, Cell, Digit, GameAction, GameConfig, GameState } from "./types";
+
+export function createEmptyBoard(): Board {
+	const board: Board = [];
+	for (let r = 0; r < 9; r++) {
+		const row: Cell[] = [];
+		for (let c = 0; c < 9; c++) {
+			row.push({ row: r, col: c, value: null, notes: {}, isGiven: false });
+		}
+		board.push(row);
+	}
+	return board;
+}
+
+export function getCell(board: Board, row: number, col: number): Cell {
+	if (row < 0 || row > 8 || col < 0 || col > 8) {
+		throw new Error(`Cell out of bounds: (${row}, ${col})`);
+	}
+	const rowCells = board[row];
+	if (!rowCells) throw new Error(`Missing row at (${row})`);
+	const cell = rowCells[col];
+	if (!cell) throw new Error(`Missing cell at (${row}, ${col})`);
+	return cell;
+}
+
+export function initializeGame(
+	givens: { row: number; col: number; value: Digit }[],
+	config: GameConfig
+): GameState {
+	const board = createEmptyBoard();
+	for (const g of givens) {
+		const cell = getCell(board, g.row, g.col);
+		cell.value = g.value;
+		cell.isGiven = true;
+		cell.notes = {};
+	}
+	return {
+		board,
+		givens: [...givens],
+		config,
+		livesRemaining: config.maxLives,
+	};
+}
+
+export function applyAction(state: GameState, action: GameAction): GameState {
+	const next: GameState = {
+		...state,
+		board: state.board.map((row) => row.map((cell) => ({ ...cell, notes: { ...cell.notes } }))),
+	};
+	const cell = getCell(next.board, action.row, action.col);
+	if (cell.isGiven) {
+		return next; // ignore edits to givens
+	}
+	if (action.type === "place") {
+		cell.value = action.value;
+		cell.notes = {};
+		return next;
+	}
+	if (action.type === "note") {
+		if (cell.value) cell.value = null; // typing a note clears value
+		if (action.present) {
+			cell.notes[action.value] = true;
+		} else {
+			delete cell.notes[action.value];
+		}
+		return next;
+	}
+	if (action.type === "erase") {
+		cell.value = null;
+		cell.notes = {};
+		return next;
+	}
+	return next;
+}
+
+

--- a/app/game/types.ts
+++ b/app/game/types.ts
@@ -1,0 +1,37 @@
+export type Digit = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+export type CellValue = Digit | null;
+
+export type CellNotes = Partial<Record<Digit, true>>;
+
+export type Cell = {
+	row: number; // 0..8
+	col: number; // 0..8
+	value: CellValue;
+	notes: CellNotes;
+	isGiven: boolean;
+};
+
+export type Board = Cell[][]; // 9x9 grid
+
+export type Difficulty = "easy" | "medium" | "hard";
+
+export type GameConfig = {
+	difficulty: Difficulty;
+	maxLives: number; // for classic mistakes
+};
+
+export type GameState = {
+	board: Board;
+	givens: { row: number; col: number; value: Digit }[];
+	config: GameConfig;
+	livesRemaining: number;
+};
+
+export type PlaceAction = { type: "place"; row: number; col: number; value: Digit | null };
+export type NoteAction = { type: "note"; row: number; col: number; value: Digit; present: boolean };
+export type EraseAction = { type: "erase"; row: number; col: number };
+
+export type GameAction = PlaceAction | NoteAction | EraseAction;
+
+


### PR DESCRIPTION
Implements sub-issue #25.\n\n- Adds pp/game/types.ts for core types\n- Adds pp/game/state.ts with initializer and reducer-like applyAction\n- Adds pp/game/rules.ts with isSolved\n- Tests in __tests__/game/state.test.ts\n- All quality gates green locally\n\nCloses #25 when merged into epic branch.