### PR TITLE
feat(ui): 9×9 board rendering with selection & givens styling (#26)

### DIFF
--- a/__tests__/components/Board.test.tsx
+++ b/__tests__/components/Board.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import Board from '../../app/components/Board';
+import { createEmptyBoard, getCell } from '../../app/game/state';
+import type { Digit } from '../../app/game/types';
+
+describe('Board component', () => {
+	it('renders a 9x9 grid with givens styled', () => {
+		const board = createEmptyBoard();
+		// set a given and a normal value
+		getCell(board, 0, 0).value = 5 as Digit;
+		getCell(board, 0, 0).isGiven = true;
+		render(<Board board={board} selected={{ row: 0, col: 0 }} onSelect={() => {}} />);
+		const cell = screen.getByLabelText('Cell 1,1');
+		expect(cell).toBeTruthy();
+	});
+
+	it('calls onSelect when a cell is pressed and shows selection ring', () => {
+		const board = createEmptyBoard();
+		const onSelect = jest.fn();
+		render(<Board board={board} selected={{ row: 4, col: 4 }} onSelect={onSelect} />);
+		const cell = screen.getByLabelText('Cell 5,5');
+		fireEvent.press(cell);
+		expect(onSelect).toHaveBeenCalledWith(4, 4);
+	});
+});
+
+
+

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -1,21 +1,23 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, Text } from "react-native";
+import Board from "./components/Board";
+import { initializeGame } from "./game/state";
+import type { Digit } from "./game/types";
 
 export default function ClassicScreen() {
+	const state = initializeGame(
+		[
+			{ row: 0, col: 0, value: 5 as Digit },
+			{ row: 1, col: 3, value: 2 as Digit },
+		],
+		{ difficulty: "easy", maxLives: 3 }
+	);
+	const [selected, setSelected] = useState<{ row: number; col: number } | null>({ row: 0, col: 0 });
 	return (
-		<View
-			style={{
-				flex: 1,
-				alignItems: "center",
-				justifyContent: "center",
-			}}
-		>
-			<Text style={{ fontSize: 28, fontWeight: "700", marginBottom: 8 }}>
-				Classic
-			</Text>
-			<Text style={{ fontSize: 16, opacity: 0.7 }}>
-				9×9 Classic Sudoku
-			</Text>
+		<View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 12 }}>
+			<Text style={{ fontSize: 28, fontWeight: "700", marginBottom: 4 }}>Classic</Text>
+			<Text style={{ fontSize: 16, opacity: 0.7, marginBottom: 12 }}>9×9 Classic Sudoku</Text>
+			<Board board={state.board} selected={selected} onSelect={(r, c) => setSelected({ row: r, col: c })} />
 		</View>
 	);
 }

--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import type { Board as BoardType } from "../game/types";
+
+export type BoardProps = {
+	board: BoardType;
+	selected: { row: number; col: number } | null;
+	onSelect: (row: number, col: number) => void;
+};
+
+export default function Board({ board, selected, onSelect }: BoardProps) {
+	return (
+		<View>
+			{board.map((row, r) => (
+				<View key={r} style={{ flexDirection: "row" }}>
+					{row.map((cell, c) => {
+						const isSelected = selected && selected.row === r && selected.col === c;
+						const borderColor = isSelected ? "#2563eb" : "#d1d5db";
+						const backgroundColor = cell.isGiven ? "#f4f4f5" : "#ffffff";
+						return (
+							<Pressable
+								key={c}
+								onPress={() => onSelect(r, c)}
+								accessibilityRole="button"
+								accessibilityLabel={`Cell ${r + 1},${c + 1}`}
+								style={{
+									width: 36,
+									height: 36,
+									alignItems: "center",
+									justifyContent: "center",
+									borderWidth: 1,
+									borderColor,
+									backgroundColor,
+									marginRight: c % 3 === 2 ? 6 : 0,
+									marginBottom: r % 3 === 2 ? 6 : 0,
+								}}
+							>
+								<Text style={{ fontSize: 18, fontWeight: cell.isGiven ? "700" : "400" }}>
+									{cell.value ?? ""}
+								</Text>
+							</Pressable>
+						);
+					})}
+				</View>
+			))}
+		</View>
+	);
+}
+
+


### PR DESCRIPTION
Implements sub-issue #26.\n\n- New pp/components/Board.tsx\n- Integrated into pp/classic.tsx with simple selection state\n- Tests in __tests__/components/Board.test.tsx\n- All checks green locally\n\nCloses #26 when merged into epic branch.