### PR TITLE
feat(ui): Numpad 1–9 with lock toggle (#27)

### DIFF
--- a/__tests__/app/classic.numpad.test.tsx
+++ b/__tests__/app/classic.numpad.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+
+describe('ClassicScreen + Numpad integration', () => {
+	it('places a digit on selected cell and supports lock', () => {
+		render(<ClassicScreen />);
+		// Choose a non-given cell (1,2), then place 7
+		const cell12 = screen.getByLabelText('Cell 1,2');
+		fireEvent.press(cell12);
+		const d7 = screen.getByLabelText('Digit 7');
+		fireEvent.press(d7);
+		expect(cell12).toHaveTextContent('7');
+		// Lock 3 via long press, select another cell and ensure placement applies on select
+		const d3 = screen.getByLabelText('Digit 3');
+		fireEvent(d3, 'onLongPress');
+		const target = screen.getByLabelText('Cell 1,3');
+		fireEvent.press(target);
+		expect(target).toHaveTextContent('3');
+	});
+});
+
+

--- a/__tests__/components/Numpad.test.tsx
+++ b/__tests__/components/Numpad.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import Numpad from '../../app/components/Numpad';
+
+describe('Numpad component', () => {
+	it('renders digits and calls handlers', () => {
+		const onDigit = jest.fn();
+		const onToggleLock = jest.fn();
+		render(<Numpad lockedDigit={null} onDigit={onDigit} onToggleLock={onToggleLock} />);
+		const d5 = screen.getByLabelText('Digit 5');
+		fireEvent.press(d5);
+		expect(onDigit).toHaveBeenCalledWith(5);
+		fireEvent(d5, 'onLongPress');
+		expect(onToggleLock).toHaveBeenCalledWith(5);
+	});
+});
+
+

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -1,23 +1,45 @@
 import React, { useState } from "react";
 import { View, Text } from "react-native";
 import Board from "./components/Board";
-import { initializeGame } from "./game/state";
+import { initializeGame, applyAction } from "./game/state";
 import type { Digit } from "./game/types";
+import Numpad from "./components/Numpad";
 
 export default function ClassicScreen() {
-	const state = initializeGame(
-		[
-			{ row: 0, col: 0, value: 5 as Digit },
-			{ row: 1, col: 3, value: 2 as Digit },
-		],
-		{ difficulty: "easy", maxLives: 3 }
+	const [game, setGame] = useState(() =>
+		initializeGame(
+			[
+				{ row: 0, col: 0, value: 5 as Digit },
+				{ row: 1, col: 3, value: 2 as Digit },
+			],
+			{ difficulty: "easy", maxLives: 3 }
+		)
 	);
 	const [selected, setSelected] = useState<{ row: number; col: number } | null>({ row: 0, col: 0 });
+	const [lockedDigit, setLockedDigit] = useState<Digit | null>(null);
 	return (
 		<View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 12 }}>
 			<Text style={{ fontSize: 28, fontWeight: "700", marginBottom: 4 }}>Classic</Text>
 			<Text style={{ fontSize: 16, opacity: 0.7, marginBottom: 12 }}>9×9 Classic Sudoku</Text>
-			<Board board={state.board} selected={selected} onSelect={(r, c) => setSelected({ row: r, col: c })} />
+			<Board
+				board={game.board}
+				selected={selected}
+				onSelect={(r, c) => {
+					setSelected({ row: r, col: c });
+					if (lockedDigit != null) {
+						setGame((prev) => applyAction(prev, { type: "place", row: r, col: c, value: lockedDigit }));
+					}
+				}}
+			/>
+			<Numpad
+				lockedDigit={lockedDigit}
+				onDigit={(d) => {
+					if (!selected) return;
+					const value = lockedDigit ?? d;
+					setGame((prev) => applyAction(prev, { type: "place", row: selected.row, col: selected.col, value }));
+				}}
+				onToggleLock={(d) => setLockedDigit((prev) => (prev === d ? null : d))}
+			/>
 		</View>
 	);
 }

--- a/app/components/Numpad.tsx
+++ b/app/components/Numpad.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import type { Digit } from "../game/types";
+
+export type NumpadProps = {
+	lockedDigit: Digit | null;
+	onDigit: (digit: Digit) => void;
+	onToggleLock: (digit: Digit) => void;
+};
+
+const digits: Digit[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+export default function Numpad({ lockedDigit, onDigit, onToggleLock }: NumpadProps) {
+	return (
+		<View style={{ marginTop: 16 }}>
+			<View style={{ flexDirection: "row", flexWrap: "wrap", width: 36 * 9 + 8 }}>
+				{digits.map((d) => {
+					const isLocked = lockedDigit === d;
+					return (
+						<View key={d} style={{ marginRight: 4, marginBottom: 8 }}>
+							<Pressable
+								onPress={() => onDigit(d)}
+								onLongPress={() => onToggleLock(d)}
+								accessibilityRole="button"
+								accessibilityLabel={`Digit ${d}${isLocked ? " locked" : ""}`}
+								style={{
+									width: 36,
+									height: 36,
+									alignItems: "center",
+									justifyContent: "center",
+									borderWidth: 1,
+									borderColor: isLocked ? "#2563eb" : "#d1d5db",
+									borderRadius: 6,
+									backgroundColor: isLocked ? "#dbeafe" : "#ffffff",
+								}}
+							>
+								<Text style={{ fontSize: 18, fontWeight: isLocked ? "700" : "500" }}>{d}</Text>
+							</Pressable>
+						</View>
+					);
+				})}
+			</View>
+			<Text style={{ fontSize: 12, opacity: 0.7 }}>Long-press to lock a digit</Text>
+		</View>
+	);
+}
+
+


### PR DESCRIPTION
Implements sub-issue #27.\n\n- pp/components/Numpad.tsx\n- Integrated into pp/classic.tsx with placement behavior and lock on long-press\n- Tests: __tests__/components/Numpad.test.tsx, __tests__/app/classic.numpad.test.tsx\n- All checks green locally\n\nCloses #27 when merged into epic branch.