### PR TITLE
fix(router): add <Slot /> to layout; routes render properly (Fixes #72)

### DIFF
--- a/__tests__/app/_layout.test.tsx
+++ b/__tests__/app/_layout.test.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import RootLayout from '../../app/_layout';
 
+jest.mock('expo-router', () => ({ Slot: () => null }));
+
 describe('RootLayout', () => {
-	it('renders text and allows theme toggle', () => {
+	it('renders Slot and allows theme toggle', () => {
 		render(<RootLayout />);
-		expect(screen.getByText('Hello world')).toBeTruthy();
-		expect(screen.getByText('Welcome to Ultimate Sudoku')).toBeTruthy();
-		// Toggle exists and can be pressed
+		// Toggle exists and can be pressed (we don't have a router context here)
 		const toggle = screen.getByLabelText('Toggle color theme');
 		fireEvent.press(toggle);
-		// Index should include a Classic link rendered by nested route
-		// Note: we only assert that label exists when Index is mounted within router
 	});
 });
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Platform, useColorScheme, Pressable, Text, View, Appearance } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
+import { Slot } from "expo-router";
 import * as SystemUI from "expo-system-ui";
  
 if (Platform.OS === "web") {
@@ -83,13 +84,8 @@ export default function RootLayout() {
 						</Pressable>
 					</View>
 				</SafeAreaView>
-				<View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-					<Text style={{ fontSize: 28, fontWeight: "700", marginBottom: 8, color: theme.foreground }}>
-						Hello world
-					</Text>
-					<Text style={{ fontSize: 16, opacity: 0.7, color: theme.foreground }}>
-						Welcome to Ultimate Sudoku
-					</Text>
+				<View style={{ flex: 1 }}>
+					<Slot />
 				</View>
 			</View>
 		</ThemeContext.Provider>


### PR DESCRIPTION
Fixes [#72] by adding<Slot / toapp/_layout.ts so expo-router renders nested routes. Adjusted test to mock Slot. All checks green locally.