### PR TITLE
feat(classic): Eraser behaviors for value & notes (Epic #14, #29)

### DIFF
--- a/__tests__/app/classic.eraser.test.tsx
+++ b/__tests__/app/classic.eraser.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+
+describe('ClassicScreen eraser', () => {
+    it('erases value and notes from selected cell', () => {
+        render(<ClassicScreen />);
+        // Select a cell and place a value
+        const cell12 = screen.getByLabelText('Cell 1,2');
+        fireEvent.press(cell12);
+        fireEvent.press(screen.getByLabelText('Digit 7'));
+        expect(cell12).toHaveTextContent('7');
+        // Erase value
+        fireEvent.press(screen.getByLabelText('Erase cell'));
+        expect(cell12).toHaveTextContent('');
+        // Add notes then erase
+        const notesToggle = screen.getByLabelText('Enable notes mode');
+        fireEvent.press(notesToggle);
+        fireEvent.press(screen.getByLabelText('Digit 1'));
+        fireEvent.press(screen.getByLabelText('Digit 2'));
+        const notesEl = screen.getByTestId('cell-1-2-notes');
+        expect(notesEl).toHaveTextContent('12');
+        fireEvent.press(screen.getByLabelText('Erase cell'));
+        expect(cell12).toHaveTextContent('');
+    });
+});
+

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -53,6 +53,26 @@ export default function ClassicScreen() {
 				>
 					<Text style={{ fontSize: 14, fontWeight: notesMode ? "700" : "500" }}>{notesMode ? "Notes: ON" : "Notes: OFF"}</Text>
 				</Pressable>
+				<View style={{ width: 8 }} />
+				<Pressable
+					onPress={() => {
+						if (!selected) return;
+						setGame((prev) => applyAction(prev, { type: "erase", row: selected.row, col: selected.col }));
+					}}
+					accessibilityRole="button"
+					accessibilityLabel="Erase cell"
+					style={{
+						paddingHorizontal: 12,
+						paddingVertical: 6,
+						borderWidth: 1,
+						borderColor: "#d1d5db",
+						borderRadius: 6,
+						backgroundColor: "#ffffff",
+						marginBottom: 8,
+					}}
+				>
+					<Text style={{ fontSize: 14, fontWeight: "500" }}>Erase</Text>
+				</Pressable>
 			</View>
 			<Numpad
 				lockedDigit={lockedDigit}


### PR DESCRIPTION
- Add Erase button on Classic screen that clears value and notes for selected cell.
- Covered by new integration test.
- CI green locally.

Closes #29.
