### PR TITLE
feat(game): undo/redo wired to UI (Epic #14, #31)

### DIFF
--- a/__tests__/app/classic.undo-redo.test.tsx
+++ b/__tests__/app/classic.undo-redo.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+
+describe('ClassicScreen undo/redo', () => {
+    it('undoes and redoes moves', () => {
+        render(<ClassicScreen />);
+        const cell12 = screen.getByLabelText('Cell 1,2');
+        fireEvent.press(cell12);
+        fireEvent.press(screen.getByLabelText('Digit 4'));
+        expect(cell12).toHaveTextContent('4');
+        fireEvent.press(screen.getByLabelText('Undo move'));
+        expect(cell12).toHaveTextContent('');
+        fireEvent.press(screen.getByLabelText('Redo move'));
+        expect(cell12).toHaveTextContent('4');
+    });
+});
+

--- a/app/_game/state.ts
+++ b/app/_game/state.ts
@@ -41,6 +41,7 @@ export function initializeGame(
 		givens: [...givens],
 		config,
 		livesRemaining: config.maxLives,
+		history: { past: [], future: [] },
 	};
 }
 
@@ -49,41 +50,73 @@ export function applyAction(state: GameState, action: GameAction): GameState {
 		...state,
 		board: state.board.map((row) => row.map((cell) => ({ ...cell, notes: { ...cell.notes } }))),
 	};
-	const cell = getCell(next.board, action.row, action.col);
-	if (cell.isGiven) {
-		return next; // ignore edits to givens
+	// Undo/Redo without coordinates
+	if (action.type === "undo") {
+		const prev = state.history.past[state.history.past.length - 1];
+		if (!prev) return state;
+		const newPast = state.history.past.slice(0, -1);
+		const newFuture = [{ board: state.board, livesRemaining: state.livesRemaining }, ...state.history.future];
+		return { ...state, board: prev.board, livesRemaining: prev.livesRemaining, history: { past: newPast, future: newFuture } };
 	}
-	if (action.type === "place") {
-		// reset notes/error first
-		cell.notes = {};
-		cell.isError = false;
-		if (action.value == null) {
-			cell.value = null;
-			return next;
-		}
-		if (!isValidPlacement(next.board, action.row, action.col, action.value)) {
+	if (action.type === "redo") {
+		const fut = state.history.future[0];
+		if (!fut) return state;
+		const newFuture = state.history.future.slice(1);
+		const newPast = [...state.history.past, { board: state.board, livesRemaining: state.livesRemaining }];
+		return { ...state, board: fut.board, livesRemaining: fut.livesRemaining, history: { past: newPast, future: newFuture } };
+	}
+
+	switch (action.type) {
+		case "place": {
+			next.history = {
+				past: [...state.history.past, { board: state.board, livesRemaining: state.livesRemaining }],
+				future: [],
+			};
+			const cell = getCell(next.board, action.row, action.col);
+			if (cell.isGiven) return next;
+			cell.notes = {};
+			cell.isError = false;
+			if (action.value == null) {
+				cell.value = null;
+				return next;
+			}
+			if (!isValidPlacement(next.board, action.row, action.col, action.value)) {
+				cell.value = action.value;
+				cell.isError = true;
+				next.livesRemaining = Math.max(0, next.livesRemaining - 1);
+				return next;
+			}
 			cell.value = action.value;
-			cell.isError = true;
-			next.livesRemaining = Math.max(0, next.livesRemaining - 1);
 			return next;
 		}
-		cell.value = action.value;
-		return next;
-	}
-	if (action.type === "note") {
-		if (cell.value) cell.value = null; // typing a note clears value
-		if (action.present) {
-			cell.notes[action.value] = true;
-		} else {
-			delete cell.notes[action.value];
+		case "note": {
+			next.history = {
+				past: [...state.history.past, { board: state.board, livesRemaining: state.livesRemaining }],
+				future: [],
+			};
+			const cell = getCell(next.board, action.row, action.col);
+			if (cell.isGiven) return next;
+			if (cell.value) cell.value = null; // typing a note clears value
+			if (action.present) {
+				cell.notes[action.value] = true;
+			} else {
+				delete cell.notes[action.value];
+			}
+			return next;
 		}
-		return next;
+		case "erase": {
+			next.history = {
+				past: [...state.history.past, { board: state.board, livesRemaining: state.livesRemaining }],
+				future: [],
+			};
+			const cell = getCell(next.board, action.row, action.col);
+			if (cell.isGiven) return next;
+			cell.value = null;
+			cell.notes = {};
+			cell.isError = false;
+			return next;
+		}
+		default:
+			return next;
 	}
-	if (action.type === "erase") {
-		cell.value = null;
-		cell.notes = {};
-		cell.isError = false;
-		return next;
-	}
-	return next;
 }

--- a/app/_game/state.ts
+++ b/app/_game/state.ts
@@ -65,7 +65,7 @@ export function applyAction(state: GameState, action: GameAction): GameState {
 		const newPast = [...state.history.past, { board: state.board, livesRemaining: state.livesRemaining }];
 		return { ...state, board: fut.board, livesRemaining: fut.livesRemaining, history: { past: newPast, future: newFuture } };
 	}
-
+	// Coord-based actions with proper narrowing
 	switch (action.type) {
 		case "place": {
 			next.history = {
@@ -73,7 +73,7 @@ export function applyAction(state: GameState, action: GameAction): GameState {
 				future: [],
 			};
 			const cell = getCell(next.board, action.row, action.col);
-			if (cell.isGiven) return next;
+			if (cell.isGiven) return next; // ignore edits to givens
 			cell.notes = {};
 			cell.isError = false;
 			if (action.value == null) {

--- a/app/_game/types.ts
+++ b/app/_game/types.ts
@@ -27,12 +27,18 @@ export type GameState = {
 	givens: { row: number; col: number; value: Digit }[];
 	config: GameConfig;
 	livesRemaining: number;
+	history: {
+		past: { board: Board; livesRemaining: number }[];
+		future: { board: Board; livesRemaining: number }[];
+	};
 };
 
 export type PlaceAction = { type: "place"; row: number; col: number; value: Digit | null };
 export type NoteAction = { type: "note"; row: number; col: number; value: Digit; present: boolean };
 export type EraseAction = { type: "erase"; row: number; col: number };
+export type UndoAction = { type: "undo" };
+export type RedoAction = { type: "redo" };
 
-export type GameAction = PlaceAction | NoteAction | EraseAction;
+export type GameAction = PlaceAction | NoteAction | EraseAction | UndoAction | RedoAction;
 
 

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import Board from "./components/Board";
 import { initializeGame, applyAction } from "./_game/state";
-import type { Digit } from "./_game/types";
+import type { Digit, GameAction } from "./_game/types";
 import Numpad from "./components/Numpad";
 
 export default function ClassicScreen() {
@@ -75,6 +75,24 @@ export default function ClassicScreen() {
 					}}
 				>
 					<Text style={{ fontSize: 14, fontWeight: "500" }}>Erase</Text>
+				</Pressable>
+				<View style={{ width: 8 }} />
+				<Pressable
+					onPress={() => setGame((prev) => applyAction(prev, { type: "undo" } as GameAction))}
+					accessibilityRole="button"
+					accessibilityLabel="Undo move"
+					style={{ paddingHorizontal: 12, paddingVertical: 6, borderWidth: 1, borderColor: "#d1d5db", borderRadius: 6, backgroundColor: "#ffffff", marginBottom: 8 }}
+				>
+					<Text style={{ fontSize: 14, fontWeight: "500" }}>Undo</Text>
+				</Pressable>
+				<View style={{ width: 8 }} />
+				<Pressable
+					onPress={() => setGame((prev) => applyAction(prev, { type: "redo" } as GameAction))}
+					accessibilityRole="button"
+					accessibilityLabel="Redo move"
+					style={{ paddingHorizontal: 12, paddingVertical: 6, borderWidth: 1, borderColor: "#d1d5db", borderRadius: 6, backgroundColor: "#ffffff", marginBottom: 8 }}
+				>
+					<Text style={{ fontSize: 14, fontWeight: "500" }}>Redo</Text>
 				</Pressable>
 			</View>
 			<Numpad


### PR DESCRIPTION
- Add history with undo/redo actions in game state; UI buttons for Undo/Redo on Classic screen.
- Refactor applyAction with switch-based narrowing; tests added for undo/redo.
- CI green locally (lint, typecheck, tests, build).

Closes #31.
