### PR TITLE
feat(storage): local persistence for sudoku-progress (Epic #14, #33)

### DIFF
--- a/__tests__/app/classic.storage.test.tsx
+++ b/__tests__/app/classic.storage.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+
+describe('ClassicScreen storage', () => {
+    it('saves and loads progress (board values)', async () => {
+        // JSDOM localStorage is available
+        const { unmount } = render(<ClassicScreen />);
+        const cell12 = screen.getByLabelText('Cell 1,2');
+        fireEvent.press(cell12);
+        fireEvent.press(screen.getByLabelText('Digit 9'));
+        expect(cell12).toHaveTextContent('9');
+        // Trigger unmount/mount to simulate reload
+        unmount();
+        render(<ClassicScreen />);
+        // Value should be restored (loaded async)
+        await waitFor(() => expect(screen.getByLabelText('Cell 1,2')).toHaveTextContent('9'));
+    });
+});
+

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -4,6 +4,7 @@ import Board from "./components/Board";
 import { initializeGame, applyAction } from "./_game/state";
 import type { Digit, GameAction } from "./_game/types";
 import Numpad from "./components/Numpad";
+import { loadProgress, saveProgress } from "./services/storage";
 
 export default function ClassicScreen() {
 	const [game, setGame] = useState(() =>
@@ -21,6 +22,20 @@ export default function ClassicScreen() {
 	const [seconds, setSeconds] = useState(0);
 	const [paused, setPaused] = useState(false);
 	const timerRef = useRef<ReturnType<typeof globalThis.setInterval> | null>(null);
+
+	// Load progress on mount
+	useEffect(() => {
+		loadProgress<{ board: typeof game.board }>("sudoku-progress").then((saved) => {
+			if (saved && saved.board) {
+				setGame((prev) => ({ ...prev, board: saved.board }));
+			}
+		});
+	}, []);
+
+	// Persist on game changes
+	useEffect(() => {
+		saveProgress("sudoku-progress", { board: game.board });
+	}, [game.board]);
 
 	useEffect(() => {
 		if (paused) {

--- a/app/services/storage.ts
+++ b/app/services/storage.ts
@@ -1,0 +1,30 @@
+// Lightweight wrapper for web/local testing. For native, this could switch to AsyncStorage.
+const memoryStore = new Map<string, string>();
+export async function saveProgress(key: string, value: unknown): Promise<void> {
+    try {
+        const payload = JSON.stringify(value);
+        if (typeof window !== 'undefined' && 'localStorage' in window && window.localStorage) {
+            window.localStorage.setItem(key, payload);
+        } else {
+            memoryStore.set(key, payload);
+        }
+    } catch {
+        // ignore serialization/storage errors in tests
+    }
+}
+
+export async function loadProgress<T>(key: string): Promise<T | null> {
+    try {
+        if (typeof window !== 'undefined' && 'localStorage' in window && window.localStorage) {
+            const raw = window.localStorage.getItem(key);
+            if (!raw) return null;
+            return JSON.parse(raw) as T;
+        } else if (memoryStore.has(key)) {
+            return JSON.parse(memoryStore.get(key)!) as T;
+        }
+    } catch {
+        // ignore parse/storage errors in tests
+    }
+    return null;
+}
+


### PR DESCRIPTION
- Add storage service with localStorage/memory fallback.
- Wire Classic screen to load/save board to key 'sudoku-progress'.
- Added integration test; CI green.

Closes #33.
