### PR TITLE
feat(input): keyboard basics on web (Epic #14, #35)

### DIFF
--- a/__tests__/app/classic.keyboard.test.tsx
+++ b/__tests__/app/classic.keyboard.test.tsx
@@ -4,26 +4,30 @@ import ClassicScreen from '../../app/classic';
 
 describe('ClassicScreen keyboard', () => {
     it('handles arrow keys, digits, N toggle, and Backspace on web', () => {
-        // JSDOM simulates web
+        let saved: ((e: { key: string }) => void) | null = null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        jest.spyOn(window, 'addEventListener').mockImplementation(((type: string, handler: any) => {
+            if (type === 'keydown') saved = handler as (e: { key: string }) => void;
+        }) as unknown as typeof window.addEventListener);
+
         render(<ClassicScreen />);
         const cell12 = screen.getByLabelText('Cell 1,2');
         fireEvent.press(cell12);
         // Digit
-        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: '7' }));
+        saved && saved({ key: '7' });
         expect(cell12).toHaveTextContent('7');
         // N toggle
-        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: 'n' }));
-        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: '3' }));
+        saved && saved({ key: 'n' });
+        saved && saved({ key: '3' });
         const notesEl = screen.getByTestId('cell-1-2-notes');
         expect(notesEl).toHaveTextContent('3');
         // Backspace erase
-        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: 'Backspace' }));
+        saved && saved({ key: 'Backspace' });
         expect(cell12).toHaveTextContent('');
         // Arrows move selection
-        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: 'ArrowRight' }));
-        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: '7' }));
+        saved && saved({ key: 'ArrowRight' });
+        saved && saved({ key: '7' });
         const cell13 = screen.getByLabelText('Cell 1,3');
         expect(cell13).toHaveTextContent('7');
     });
 });
-

--- a/__tests__/app/classic.keyboard.test.tsx
+++ b/__tests__/app/classic.keyboard.test.tsx
@@ -9,19 +9,19 @@ describe('ClassicScreen keyboard', () => {
         const cell12 = screen.getByLabelText('Cell 1,2');
         fireEvent.press(cell12);
         // Digit
-        fireEvent.keyDown(window, { key: '7' });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: '7' }));
         expect(cell12).toHaveTextContent('7');
         // N toggle
-        fireEvent.keyDown(window, { key: 'n' });
-        fireEvent.keyDown(window, { key: '3' });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n' }));
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }));
         const notesEl = screen.getByTestId('cell-1-2-notes');
         expect(notesEl).toHaveTextContent('3');
         // Backspace erase
-        fireEvent.keyDown(window, { key: 'Backspace' });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace' }));
         expect(cell12).toHaveTextContent('');
         // Arrows move selection
-        fireEvent.keyDown(window, { key: 'ArrowRight' });
-        fireEvent.keyDown(window, { key: '7' });
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: '7' }));
         const cell13 = screen.getByLabelText('Cell 1,3');
         expect(cell13).toHaveTextContent('7');
     });

--- a/__tests__/app/classic.keyboard.test.tsx
+++ b/__tests__/app/classic.keyboard.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+
+describe('ClassicScreen keyboard', () => {
+    it('handles arrow keys, digits, N toggle, and Backspace on web', () => {
+        // JSDOM simulates web
+        render(<ClassicScreen />);
+        const cell12 = screen.getByLabelText('Cell 1,2');
+        fireEvent.press(cell12);
+        // Digit
+        fireEvent.keyDown(window, { key: '7' });
+        expect(cell12).toHaveTextContent('7');
+        // N toggle
+        fireEvent.keyDown(window, { key: 'n' });
+        fireEvent.keyDown(window, { key: '3' });
+        const notesEl = screen.getByTestId('cell-1-2-notes');
+        expect(notesEl).toHaveTextContent('3');
+        // Backspace erase
+        fireEvent.keyDown(window, { key: 'Backspace' });
+        expect(cell12).toHaveTextContent('');
+        // Arrows move selection
+        fireEvent.keyDown(window, { key: 'ArrowRight' });
+        fireEvent.keyDown(window, { key: '7' });
+        const cell13 = screen.getByLabelText('Cell 1,3');
+        expect(cell13).toHaveTextContent('7');
+    });
+});
+

--- a/__tests__/app/classic.keyboard.test.tsx
+++ b/__tests__/app/classic.keyboard.test.tsx
@@ -9,19 +9,19 @@ describe('ClassicScreen keyboard', () => {
         const cell12 = screen.getByLabelText('Cell 1,2');
         fireEvent.press(cell12);
         // Digit
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: '7' }));
+        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: '7' }));
         expect(cell12).toHaveTextContent('7');
         // N toggle
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n' }));
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }));
+        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: 'n' }));
+        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: '3' }));
         const notesEl = screen.getByTestId('cell-1-2-notes');
         expect(notesEl).toHaveTextContent('3');
         // Backspace erase
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace' }));
+        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: 'Backspace' }));
         expect(cell12).toHaveTextContent('');
         // Arrows move selection
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: '7' }));
+        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: 'ArrowRight' }));
+        window.dispatchEvent(new (window as any).KeyboardEvent('keydown', { key: '7' }));
         const cell13 = screen.getByLabelText('Cell 1,3');
         expect(cell13).toHaveTextContent('7');
     });

--- a/__tests__/app/classic.timer.test.tsx
+++ b/__tests__/app/classic.timer.test.tsx
@@ -7,24 +7,24 @@ jest.useFakeTimers();
 describe('ClassicScreen timer', () => {
     it('increments time and can pause/resume', () => {
         render(<ClassicScreen />);
-        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent('Time: 0:00');
+        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent(/Time: 0:00/);
         act(() => {
             jest.advanceTimersByTime(3100);
         });
-        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent('Time: 0:03');
+        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent(/Time: 0:03/);
         const pauseBtn = screen.getByLabelText('Pause timer');
         fireEvent.press(pauseBtn);
         act(() => {
             jest.advanceTimersByTime(3000);
         });
         // Still 3 seconds while paused
-        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent('Time: 0:03');
+        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent(/Time: 0:03/);
         const resumeBtn = screen.getByLabelText('Resume timer');
         fireEvent.press(resumeBtn);
         act(() => {
             jest.advanceTimersByTime(2000);
         });
-        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent('Time: 0:05');
+        expect(screen.getByLabelText('Elapsed time')).toHaveTextContent(/Time: 0:05/);
     });
 });
 

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -5,6 +5,7 @@ import { initializeGame, applyAction } from "./_game/state";
 import type { Digit, GameAction } from "./_game/types";
 import Numpad from "./components/Numpad";
 import { loadProgress, saveProgress } from "./services/storage";
+import { Platform } from "react-native";
 
 export default function ClassicScreen() {
 	const [game, setGame] = useState(() =>
@@ -54,6 +55,34 @@ export default function ClassicScreen() {
 	useEffect(() => {
 		// no-op stub
 	}, []);
+
+	// Keyboard: arrows, digits, N, Backspace (web only)
+	useEffect(() => {
+		if (Platform.OS !== 'web') return;
+		type KeyEvt = { key: string };
+		const handler = (e: KeyEvt) => {
+			if (!selected) return;
+			if (e.key === 'ArrowUp') setSelected(({ row, col }) => ({ row: Math.max(0, row - 1), col }));
+			else if (e.key === 'ArrowDown') setSelected(({ row, col }) => ({ row: Math.min(8, row + 1), col }));
+			else if (e.key === 'ArrowLeft') setSelected(({ row, col }) => ({ row, col: Math.max(0, col - 1) }));
+			else if (e.key === 'ArrowRight') setSelected(({ row, col }) => ({ row, col: Math.min(8, col + 1) }));
+			else if (/^[1-9]$/.test(e.key)) {
+				const d = Number(e.key) as Digit;
+				const value = lockedDigit ?? d;
+				setGame((prev) =>
+					notesMode
+						? applyAction(prev, { type: 'note', row: selected.row, col: selected.col, value, present: true })
+						: applyAction(prev, { type: 'place', row: selected.row, col: selected.col, value })
+				);
+			} else if (e.key === 'Backspace') {
+				setGame((prev) => applyAction(prev, { type: 'erase', row: selected.row, col: selected.col }));
+			} else if (e.key.toLowerCase() === 'n') {
+				setNotesMode((p) => !p);
+			}
+		};
+		window.addEventListener('keydown', handler);
+		return () => window.removeEventListener('keydown', handler);
+	}, [selected, lockedDigit, notesMode]);
 	return (
 		<View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 12 }}>
 			<Text style={{ fontSize: 28, fontWeight: "700", marginBottom: 4 }}>Classic</Text>

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -61,21 +61,24 @@ export default function ClassicScreen() {
 		if (Platform.OS !== 'web') return;
 		type KeyEvt = { key: string };
 		const handler = (e: KeyEvt) => {
-			if (!selected) return;
-			if (e.key === 'ArrowUp') setSelected(({ row, col }) => ({ row: Math.max(0, row - 1), col }));
-			else if (e.key === 'ArrowDown') setSelected(({ row, col }) => ({ row: Math.min(8, row + 1), col }));
-			else if (e.key === 'ArrowLeft') setSelected(({ row, col }) => ({ row, col: Math.max(0, col - 1) }));
-			else if (e.key === 'ArrowRight') setSelected(({ row, col }) => ({ row, col: Math.min(8, col + 1) }));
+			if (e.key === 'ArrowUp') setSelected((curr) => curr ? { row: Math.max(0, curr.row - 1), col: curr.col } : { row: 0, col: 0 });
+			else if (e.key === 'ArrowDown') setSelected((curr) => curr ? { row: Math.min(8, curr.row + 1), col: curr.col } : { row: 0, col: 0 });
+			else if (e.key === 'ArrowLeft') setSelected((curr) => curr ? { row: curr.row, col: Math.max(0, curr.col - 1) } : { row: 0, col: 0 });
+			else if (e.key === 'ArrowRight') setSelected((curr) => curr ? { row: curr.row, col: Math.min(8, curr.col + 1) } : { row: 0, col: 0 });
 			else if (/^[1-9]$/.test(e.key)) {
 				const d = Number(e.key) as Digit;
 				const value = lockedDigit ?? d;
-				setGame((prev) =>
-					notesMode
-						? applyAction(prev, { type: 'note', row: selected.row, col: selected.col, value, present: true })
-						: applyAction(prev, { type: 'place', row: selected.row, col: selected.col, value })
-				);
+				setGame((prev) => {
+					const sel = selected ?? { row: 0, col: 0 };
+					return notesMode
+						? applyAction(prev, { type: 'note', row: sel.row, col: sel.col, value, present: true })
+						: applyAction(prev, { type: 'place', row: sel.row, col: sel.col, value })
+				});
 			} else if (e.key === 'Backspace') {
-				setGame((prev) => applyAction(prev, { type: 'erase', row: selected.row, col: selected.col }));
+				setGame((prev) => {
+					const sel = selected ?? { row: 0, col: 0 };
+					return applyAction(prev, { type: 'erase', row: sel.row, col: sel.col });
+				});
 			} else if (e.key.toLowerCase() === 'n') {
 				setNotesMode((p) => !p);
 			}


### PR DESCRIPTION
- Add arrow navigation, digits entry, N toggle for notes, and Backspace erase on web.
- Tests included; CI green locally.

Closes #35.
