### PR TITLE
Classic: Seed footer – copy to clipboard (#63)

### DIFF
--- a/docs/qa/features/01-gameplay-controls.feature
+++ b/docs/qa/features/01-gameplay-controls.feature
@@ -77,7 +77,7 @@ Feature: Gameplay and controls (MVP)
     Then I see icon-only buttons for Hint, Undo, Redo, Lock, Notes, and Erase below the numpad
     And each tool has an accessible label
 
-  @mvp @seed
+  @mvp @seed @issue-63
   Scenario: Seed copy in footer
     Given the footer displays the puzzle seed
     When I tap the seed copy control


### PR DESCRIPTION
Parent: #14\n\nImplements acceptance for #63.\n\n- Adds @issue-63 tag to BDD: seed copy scenario in docs/qa/features/01-gameplay-controls.feature.\n- SeedFooter already supports clipboard copy with confirmation toast on web/native.\n- CI: lint, types, tests, build all green locally on Node 20.x.\n\nDocs/ADRs: no architectural changes. QA feature updated.\n\nRisks: none.\n\n