### PR TITLE
Fix release process with staging and keep secrets

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,49 @@
+name: Release PR (staging)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release for merged Release PRs (staging)
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: node
+          target-branch: staging
+          repo-url: ${{ github.repository }}
+          include-component-in-tag: false
+          skip-github-pull-request: true
+          skip-github-release: false
+
+      - name: Open or update Release PR (staging)
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release-type: node
+          target-branch: staging
+          repo-url: ${{ github.repository }}
+          include-component-in-tag: false
+          skip-github-pull-request: false
+          skip-github-release: true
+          skip-labeling: false
+
+      - name: Enable auto-merge on Release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Find the open Release Please PR on staging by label
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --base staging --state open --label "autorelease: pending" --json number --jq '.[0].number')
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "No open Release Please PR found to auto-merge."
+            exit 0
+          fi
+          gh pr merge "${PR_NUMBER}" --repo "${{ github.repository }}" --auto --merge
+


### PR DESCRIPTION
Adds a new GitHub Actions workflow to correctly manage `release-please` for the `staging` branch, ensuring proper releases, tags, and auto-merge.

This workflow fixes issues with `release-please` by using supported inputs, explicitly targeting `staging` as the base branch, splitting the action into two steps (one for creating releases/tags for merged PRs, one for opening/updating the next PR), and using `gh pr merge --repo` to enable auto-merge without requiring a local git checkout.

---
<a href="https://cursor.com/background-agent?bcId=bc-477f7e24-634d-49e1-9b27-d0df3b9ac115">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-477f7e24-634d-49e1-9b27-d0df3b9ac115">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

