### PR TITLE
Classic: Persist UI toggles (notes/paused/lockedDigit) (#107)

### DIFF
--- a/__tests__/app/classic.storage.test.tsx
+++ b/__tests__/app/classic.storage.test.tsx
@@ -3,18 +3,39 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react-nativ
 import ClassicScreen from '../../app/classic';
 
 describe('ClassicScreen storage', () => {
-    it('saves and loads progress (board values)', async () => {
-        // JSDOM localStorage is available
-        const { unmount } = render(<ClassicScreen />);
-        const cell12 = screen.getByLabelText('Cell 1,2');
-        fireEvent.press(cell12);
-        fireEvent.press(screen.getByLabelText('Digit 9'));
-        expect(cell12).toHaveTextContent('9');
-        // Trigger unmount/mount to simulate reload
-        unmount();
-        render(<ClassicScreen />);
-        // Value should be restored (loaded async)
-        await waitFor(() => expect(screen.getByLabelText('Cell 1,2')).toHaveTextContent('9'));
-    });
-});
+  it('saves and loads progress (board values)', async () => {
+    // JSDOM localStorage is available
+    const { unmount } = render(<ClassicScreen />);
+    const cell12 = screen.getByLabelText('Cell 1,2');
+    fireEvent.press(cell12);
+    fireEvent.press(screen.getByLabelText('Digit 9'));
+    expect(cell12).toHaveTextContent('9');
+    // Trigger unmount/mount to simulate reload
+    unmount();
+    render(<ClassicScreen />);
+    // Value should be restored (loaded async)
+    await waitFor(() => expect(screen.getByLabelText('Cell 1,2')).toHaveTextContent('9'));
+  });
 
+  it('persists notesMode, paused, and lockedDigit', async () => {
+    const { unmount } = render(<ClassicScreen />);
+    // Enable notes mode
+    fireEvent.press(screen.getByLabelText('Enable notes mode'));
+    // Lock 4 via long press
+    const d4 = screen.getByLabelText('Digit 4');
+    fireEvent(d4, 'onLongPress');
+    // Pause
+    fireEvent.press(screen.getByLabelText('Pause timer'));
+
+    // Unmount/remount to simulate reload
+    unmount();
+    render(<ClassicScreen />);
+
+    // notes mode restored
+    await waitFor(() => expect(screen.getByLabelText('Disable notes mode')).toBeTruthy());
+    // locked digit reflected in accessibility label
+    expect(screen.getByLabelText('Digit 4 locked')).toBeTruthy();
+    // paused restored
+    expect(screen.getByLabelText('Resume timer')).toBeTruthy();
+  });
+});

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -40,16 +40,39 @@ export default function ClassicScreen() {
   }, [notesMode]);
 
   useEffect(() => {
-    loadProgress<{ board: typeof game.board }>('sudoku-progress').then((saved) => {
-      if (saved && saved.board) {
-        setGame((prev) => ({ ...prev, board: saved.board }));
+    type SavedShape = {
+      board?: typeof game.board;
+      notesMode?: boolean;
+      paused?: boolean;
+      lockedDigit?: Digit | null;
+    };
+    loadProgress<SavedShape>('sudoku-progress').then((saved) => {
+      if (!saved) return;
+      if (saved.board) {
+        setGame((prev) => ({ ...prev, board: saved.board! }));
+      }
+      if (typeof saved.notesMode === 'boolean') {
+        setNotesMode(saved.notesMode);
+        notesModeRef.current = saved.notesMode;
+      }
+      if (typeof saved.paused === 'boolean') {
+        setPaused(saved.paused);
+      }
+      if (typeof saved.lockedDigit === 'number' || saved.lockedDigit === null) {
+        setLockedDigit(saved.lockedDigit ?? null);
+        lockedRef.current = saved.lockedDigit ?? null;
       }
     });
   }, []);
 
   useEffect(() => {
-    saveProgress('sudoku-progress', { board: game.board });
-  }, [game.board]);
+    saveProgress('sudoku-progress', {
+      board: game.board,
+      notesMode: notesModeRef.current,
+      paused,
+      lockedDigit: lockedRef.current,
+    });
+  }, [game.board, paused, notesMode, lockedDigit]);
 
   useEffect(() => {
     if (paused) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Classic: Seed footer now supports copy-to-clipboard with confirmation toast (Issue #63).
 - Classic: Auto-pause implemented for AppState (native) and visibility/blur (web). Tagged BDD with @issue-105 (Issue #105).
 - Classic: Prevent default browser shortcuts/scroll for handled keys on web; add BDD @issue-106 and tests (Issue #106).
+- Classic: Persist notes mode, paused state, and locked digit across sessions; add BDD @issue-107 and tests (Issue #107).
 
 ## v0.9 — 2025-08-20
 

--- a/docs/qa/features/01-gameplay-controls.feature
+++ b/docs/qa/features/01-gameplay-controls.feature
@@ -27,6 +27,12 @@ Feature: Gameplay and controls (MVP)
     When I press the N key
     Then notes mode toggles
 
+  @mvp @storage @issue-107
+  Scenario: Persist UI toggles across sessions
+    Given I enable notes mode and pause the game and lock a digit
+    When I restart the app
+    Then notes mode, paused state, and the locked digit are restored
+
   @mvp @lock
   Scenario: Numpad lock places repeated digit
     Given the numpad lock is enabled on digit 7


### PR DESCRIPTION
Parent: #14\n\nImplements #107.\n- Persist notesMode, paused, lockedDigit in storage with migration-safe load.\n- Add tests and BDD scenario.\n- CI green locally.\n