### PR TITLE
test(ui): Numpad single-row aligned to grid (Epic 14 #110)

### DIFF
--- a/__tests__/app/classic.numpad.test.tsx
+++ b/__tests__/app/classic.numpad.test.tsx
@@ -28,4 +28,12 @@ describe('ClassicScreen + Numpad integration', () => {
       expect(el).toBeTruthy();
     }
   });
+
+  it('numpad is a single row aligned to the grid width (@issue-110)', () => {
+    render(<ClassicScreen />);
+    const row = screen.getByTestId('numpad-row');
+    expect(row.props.style.flexDirection).toBe('row');
+    // 9 cells * 36px with two 6px gutters after 3rd and 6th digit
+    expect(row.props.style.width).toBe(36 * 9 + 2 * 6);
+  });
 });


### PR DESCRIPTION
Adds integration test on Classic screen to assert numpad is a single row and width equals grid width.\n\n- Test: __tests__/app/classic.numpad.test.tsx\n- CI: lint, types, tests, build, deps, bundle, audit all green locally.\n- No app code changes needed; implementation already conforms.\n\nRefs #110 under Epic #14.