### PR TITLE
feat(ui): Tools as icons with a11y hints (Epic 14 #111)

### DIFF
--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -330,6 +330,7 @@ export default function ClassicScreen() {
           onPress={() => setNotesMode((p) => !p)}
           accessibilityRole="button"
           accessibilityLabel={notesMode ? 'Disable notes mode' : 'Enable notes mode'}
+          accessibilityHint="Toggles whether taps add notes instead of placing values"
           style={{
             width: 36,
             height: 36,
@@ -354,6 +355,7 @@ export default function ClassicScreen() {
           onPress={() => setPaused((p) => !p)}
           accessibilityRole="button"
           accessibilityLabel={paused ? 'Resume timer' : 'Pause timer'}
+          accessibilityHint={paused ? 'Resumes the game timer' : 'Pauses the game timer'}
           style={{
             width: 36,
             height: 36,
@@ -387,6 +389,7 @@ export default function ClassicScreen() {
           }}
           accessibilityRole="button"
           accessibilityLabel="Erase cell"
+          accessibilityHint="Clears the value or note in the selected cell"
           style={{
             width: 36,
             height: 36,
@@ -405,6 +408,7 @@ export default function ClassicScreen() {
           onPress={() => setGame((prev) => applyAction(prev, { type: 'undo' } as GameAction))}
           accessibilityRole="button"
           accessibilityLabel="Undo move"
+          accessibilityHint="Reverts the last action without changing lives"
           style={{
             width: 36,
             height: 36,
@@ -423,6 +427,7 @@ export default function ClassicScreen() {
           onPress={() => setGame((prev) => applyAction(prev, { type: 'redo' } as GameAction))}
           accessibilityRole="button"
           accessibilityLabel="Redo move"
+          accessibilityHint="Reapplies the last undone action without changing lives"
           style={{
             width: 36,
             height: 36,


### PR DESCRIPTION
Adds accessibility hints to tool icon buttons below the numpad to improve screen reader guidance.\n\n- File: app/classic.tsx\n- Tests: existing tools icons test covers presence and behavior; hints improve a11y without behavior change.\n- CI: lint, types, tests, build, deps, bundle, audit are green locally.\n\nRefs #111 under Epic #14.