### PR TITLE
test(ui): Header timer right-aligned (Epic 14 #112)

### DIFF
--- a/__tests__/app/classic.header.test.tsx
+++ b/__tests__/app/classic.header.test.tsx
@@ -22,4 +22,12 @@ describe('ClassicScreen header/footer', () => {
     expect(screen.getByLabelText(/\d+ lives remaining/)).toBeTruthy();
   });
   it.todo('shows timer value with an adjacent icon-only pause control (no textual "Timer" label)');
+
+  it('right-aligns the timer within header width (@issue-112)', () => {
+    render(<ClassicScreen />);
+    const time = screen.getByLabelText('Elapsed time');
+    // Ensure style positions the timer to the right within the header row container
+    expect(time.props.style.position).toBe('absolute');
+    expect(time.props.style.right).toBe(0);
+  });
 });


### PR DESCRIPTION
Adds an assertion that the header timer is right-aligned within the header row container.\n\n- Test: __tests__/app/classic.header.test.tsx\n- Implementation already matches spec; no code changes required.\n- CI: lint, types, tests, build, deps, bundle, audit green locally.\n\nRefs #112 under Epic #14.