### PR TITLE
test(game): Undo/Redo lives test updated for hearts-only label (Epic 14 #113)

### DIFF
--- a/__tests__/app/classic.lives.test.tsx
+++ b/__tests__/app/classic.lives.test.tsx
@@ -10,34 +10,29 @@ describe('ClassicScreen lives and error highlighting', () => {
     fireEvent.press(cell12);
     fireEvent.press(screen.getByLabelText('Digit 5'));
     // Try to place another 5 in same row (1,3) → invalid
-    // Note: replace with hearts a11y label when Header is updated
-    const livesBefore = screen.getByLabelText('Elapsed time');
-    const beforeText = String(
-      livesBefore.props.children.join ? livesBefore.props.children.join('') : '',
-    ).replace(/.*Lives: (\d+).*/, '$1');
+    // Read lives from hearts-only accessible label, e.g., "3 lives remaining"
+    const getLives = (): number => {
+      const node = screen.getByLabelText(/\d+ lives remaining/);
+      const label = (node as unknown as { props?: { accessibilityLabel?: string } }).props
+        ?.accessibilityLabel;
+      const match = (label ?? '').match(/(\d+) lives remaining/);
+      return match ? Number(match[1]) : NaN;
+    };
+    const beforeLives = getLives();
     const cell13 = screen.getByLabelText('Cell 1,3');
     fireEvent.press(cell13);
     fireEvent.press(screen.getByLabelText('Digit 5'));
-    const livesAfter = screen.getByLabelText('Elapsed time');
-    const afterText = String(
-      livesAfter.props.children.join ? livesAfter.props.children.join('') : '',
-    ).replace(/.*Lives: (\d+).*/, '$1');
-    expect(Number(afterText)).toBe(Number(beforeText) - 1);
+    const afterLives = getLives();
+    expect(afterLives).toBe(beforeLives - 1);
 
     // Undo should not change lives count
     fireEvent.press(screen.getByLabelText('Undo move'));
-    const livesAfterUndo = screen.getByLabelText('Elapsed time');
-    const afterUndoText = String(
-      livesAfterUndo.props.children.join ? livesAfterUndo.props.children.join('') : '',
-    ).replace(/.*Lives: (\d+).*/, '$1');
-    expect(Number(afterUndoText)).toBe(Number(afterText));
+    const livesAfterUndo = getLives();
+    expect(livesAfterUndo).toBe(afterLives);
 
     // Redo should not change lives count
     fireEvent.press(screen.getByLabelText('Redo move'));
-    const livesAfterRedo = screen.getByLabelText('Elapsed time');
-    const afterRedoText = String(
-      livesAfterRedo.props.children.join ? livesAfterRedo.props.children.join('') : '',
-    ).replace(/.*Lives: (\d+).*/, '$1');
-    expect(Number(afterRedoText)).toBe(Number(afterText));
+    const livesAfterRedo = getLives();
+    expect(livesAfterRedo).toBe(afterLives);
   });
 });


### PR DESCRIPTION
Updates lives assertions to use the header hearts-only accessible label. Undo/Redo remains verified to not change lives.\n\n- Test: __tests__/app/classic.lives.test.tsx\n- CI: lint, types, tests, build, deps, bundle, audit green locally.\n\nRefs #113 under Epic #14.