### PR TITLE
feat(classic): record win/loss stats on finish (#166)

### DIFF
--- a/__tests__/app/classic.stats.test.tsx
+++ b/__tests__/app/classic.stats.test.tsx
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+/* eslint-env jest */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+import {
+  __TEST_ONLY__clearProgress,
+  __TEST_ONLY__clearMemoryStore,
+  loadProgress,
+} from '../../app/services/storage';
+import type { StatsData } from '../../app/services/stats';
+
+describe('Classic stats persistence (#166)', () => {
+  it('records a loss when lives reach zero', async () => {
+    __TEST_ONLY__clearMemoryStore();
+    __TEST_ONLY__clearProgress('sudoku-stats');
+    __TEST_ONLY__clearProgress('sudoku-progress');
+    render(<ClassicScreen />);
+    // Force three mistakes to deplete lives
+    const cell12 = screen.getByLabelText('Cell 1,2');
+    fireEvent.press(cell12);
+    // Place 5 in (1,2)
+    fireEvent.press(screen.getByLabelText(/Digit 5( highlighted)?/));
+
+    const makeMistake = () => {
+      const cell13 = screen.getByLabelText('Cell 1,3');
+      fireEvent.press(cell13);
+      // Place another 5 in same row is invalid
+      fireEvent.press(screen.getByLabelText(/Digit 5( highlighted)?/));
+    };
+
+    makeMistake();
+    makeMistake();
+    makeMistake();
+
+    // Finished overlay should show Game over
+    expect(screen.getByLabelText('Game over')).toBeTruthy();
+
+    // Wait for async stats write to complete, then assert
+    await waitFor(async () => {
+      const parsed = await loadProgress<StatsData>('sudoku-stats');
+      expect(parsed?.totals?.played).toBe(1);
+      expect(parsed?.totals?.losses).toBe(1);
+    });
+  });
+});

--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -19,6 +19,7 @@ import { ThemeContext } from './_layout';
 import Header from './components/Header';
 import SeedFooter from './components/SeedFooter';
 import { FIXED_EASY_SEED, seedToGivens } from './game/fixtures';
+import { recordResult } from './services/stats';
 
 export default function ClassicScreen() {
   const theme = useContext(ThemeContext);
@@ -53,6 +54,7 @@ export default function ClassicScreen() {
   const gameOver = game.livesRemaining === 0;
   const solved = isSolved(game.board);
   const finished = gameOver || solved;
+  const hasRecordedRef = useRef(false);
 
   // Safely derive the currently selected cell's digit (if any)
   const selectedDigit: Digit | null = (() => {
@@ -83,6 +85,20 @@ export default function ClassicScreen() {
     setSeconds(0);
   }
 
+  useEffect(() => {
+    // On first transition to finished, record stats once
+    if (finished && !hasRecordedRef.current) {
+      hasRecordedRef.current = true;
+      const result = solved ? 'win' : ('loss' as const);
+      void recordResult(game.config.difficulty, result, seconds);
+    }
+  }, [finished, solved, game.config.difficulty, seconds]);
+
+  useEffect(() => {
+    if (!finished) {
+      hasRecordedRef.current = false;
+    }
+  }, [finished]);
   useEffect(() => {
     type SavedShape = {
       board?: typeof game.board;

--- a/app/services/stats.ts
+++ b/app/services/stats.ts
@@ -1,0 +1,55 @@
+import type { GameConfig } from '../game/types';
+import { loadProgress, saveProgress } from './storage';
+
+export type StatsResult = 'win' | 'loss';
+
+export type StatsData = {
+  schemaVersion: 1;
+  totals: {
+    played: number;
+    wins: number;
+    losses: number;
+  };
+  bestTimeByDifficulty: Partial<Record<GameConfig['difficulty'], number>>;
+};
+
+const STATS_KEY = 'sudoku-stats';
+
+export async function loadStats(): Promise<StatsData | null> {
+  return loadProgress<StatsData>(STATS_KEY);
+}
+
+export async function saveStats(data: StatsData): Promise<void> {
+  await saveProgress(STATS_KEY, data);
+}
+
+export async function recordResult(
+  difficulty: GameConfig['difficulty'],
+  result: StatsResult,
+  secondsElapsed: number,
+): Promise<void> {
+  const existing = (await loadStats()) ?? {
+    schemaVersion: 1 as const,
+    totals: { played: 0, wins: 0, losses: 0 },
+    bestTimeByDifficulty: {},
+  };
+
+  const next: StatsData = {
+    schemaVersion: 1 as const,
+    totals: {
+      played: existing.totals.played + 1,
+      wins: existing.totals.wins + (result === 'win' ? 1 : 0),
+      losses: existing.totals.losses + (result === 'loss' ? 1 : 0),
+    },
+    bestTimeByDifficulty: { ...existing.bestTimeByDifficulty },
+  };
+
+  if (result === 'win') {
+    const currentBest = next.bestTimeByDifficulty[difficulty];
+    if (typeof currentBest !== 'number' || secondsElapsed < currentBest) {
+      next.bestTimeByDifficulty[difficulty] = secondsElapsed;
+    }
+  }
+
+  await saveStats(next);
+}


### PR DESCRIPTION
Adds minimal local stats persistence for Classic mode.\n\n- Introduces stats service (schemaVersion 1): totals and best time per difficulty\n- Records result once on finish (win/loss) with elapsed seconds\n- Adds unit test for loss path and async persistence\n\nAll checks pass locally.\n\nCloses #166