### PR TITLE
feat(engine,#160): difficulty thresholds + generator integration

### DIFF
--- a/__tests__/game/difficulty.test.ts
+++ b/__tests__/game/difficulty.test.ts
@@ -1,0 +1,18 @@
+import { DIFFICULTY_THRESHOLDS, isClueCountInDifficulty } from '../../app/game/engine/difficulty';
+
+describe('difficulty thresholds (#160)', () => {
+  it('defines thresholds for easy/medium/hard', () => {
+    expect(DIFFICULTY_THRESHOLDS.easy.minClues).toBeGreaterThanOrEqual(34);
+    expect(DIFFICULTY_THRESHOLDS.medium.minClues).toBe(28);
+    expect(DIFFICULTY_THRESHOLDS.medium.maxClues).toBe(33);
+    expect(DIFFICULTY_THRESHOLDS.hard.minClues).toBe(24);
+    expect(DIFFICULTY_THRESHOLDS.hard.maxClues).toBe(27);
+  });
+
+  it('validates clue counts within ranges', () => {
+    expect(isClueCountInDifficulty('easy', 40)).toBe(true);
+    expect(isClueCountInDifficulty('medium', 30)).toBe(true);
+    expect(isClueCountInDifficulty('hard', 25)).toBe(true);
+    expect(isClueCountInDifficulty('hard', 33)).toBe(false);
+  });
+});

--- a/__tests__/game/generator.test.ts
+++ b/__tests__/game/generator.test.ts
@@ -1,4 +1,5 @@
 import { generatePuzzle } from '../../app/game/engine/generator';
+import { isClueCountInDifficulty } from '../../app/game/engine/difficulty';
 import { countSolutions, cloneGrid } from '../../app/game/engine/solver';
 
 describe('generator (#159)', () => {
@@ -29,5 +30,11 @@ describe('generator (#159)', () => {
     expect(
       countSolutions(grid as unknown as (1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | null)[][], 2),
     ).toBe(1);
+  });
+
+  it('aims clue count to match difficulty thresholds when provided', () => {
+    const { givens } = generatePuzzle({ seed: 'seed-medium', difficulty: 'medium' });
+    const clues = givens.length;
+    expect(isClueCountInDifficulty('medium', clues)).toBe(true);
   });
 });

--- a/app/game/engine/difficulty.ts
+++ b/app/game/engine/difficulty.ts
@@ -1,0 +1,21 @@
+import type { Difficulty } from '../../game/types';
+
+export type DifficultyThreshold = {
+  minClues: number;
+  maxClues: number; // inclusive upper bound
+};
+
+// Thresholds derived from product spec (MVP v0.9)
+// Easy: ≥34 clues
+// Medium: 28–33 clues
+// Hard: 24–27 clues
+export const DIFFICULTY_THRESHOLDS: Record<Difficulty, DifficultyThreshold> = {
+  easy: { minClues: 34, maxClues: 81 },
+  medium: { minClues: 28, maxClues: 33 },
+  hard: { minClues: 24, maxClues: 27 },
+};
+
+export function isClueCountInDifficulty(difficulty: Difficulty, clueCount: number): boolean {
+  const t = DIFFICULTY_THRESHOLDS[difficulty];
+  return clueCount >= t.minClues && clueCount <= t.maxClues;
+}

--- a/app/game/engine/generator.ts
+++ b/app/game/engine/generator.ts
@@ -1,10 +1,12 @@
-import type { Digit } from '../types';
+import type { Digit, Difficulty } from '../types';
 import { createRng, hashStringToSeed, shuffled } from './random';
 import { cloneGrid, countSolutions } from './solver';
+import { DIFFICULTY_THRESHOLDS } from './difficulty';
 
 export type GenerateOptions = {
   seed: string;
-  minClues?: number; // rough target
+  difficulty?: Difficulty; // if provided, aim to meet clue thresholds
+  minClues?: number; // legacy/override
 };
 
 export type GeneratedPuzzle = {
@@ -14,7 +16,7 @@ export type GeneratedPuzzle = {
 
 // Very basic generator: fill a complete valid grid randomly, then remove clues while preserving uniqueness
 export function generatePuzzle(options: GenerateOptions): GeneratedPuzzle {
-  const { seed, minClues = 28 } = options;
+  const { seed, difficulty, minClues } = options;
   const rng = createRng(hashStringToSeed(seed));
 
   // Step 1: generate full solution by backtracking with randomized order
@@ -64,8 +66,9 @@ export function generatePuzzle(options: GenerateOptions): GeneratedPuzzle {
   );
   const puzzle = cloneGrid(solution);
   let clues = 81;
+  const targetMin = minClues ?? (difficulty ? DIFFICULTY_THRESHOLDS[difficulty].minClues : 28);
   for (const [r, c] of cells) {
-    if (clues <= minClues) break;
+    if (clues <= targetMin) break;
     const backup = puzzle[r]![c]!;
     puzzle[r]![c] = null;
     const gridCopy = cloneGrid(puzzle);


### PR DESCRIPTION
Adds difficulty thresholds module and integrates clue targets into generator.\n\n- Difficulty thresholds per MVP spec for easy/medium/hard.\n- Generator uses thresholds when difficulty is provided; tests updated.\n- Local CI green.\n\nCloses #160.