### PR TITLE
ci(android): versionCode check + non-interactive prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "web": "npx expo start --web",
     "android": "npx expo run:android",
     "native:prebuild": "npx expo prebuild",
+    "android:prebuild:ci": "npx expo prebuild -p android --non-interactive",
+    "android:version:check": "node scripts/check-android-version.mjs",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --check .",
     "typecheck": "tsc --pretty --noEmit",
@@ -22,7 +24,7 @@
     "verify:deps": "node scripts/verify-deps.mjs",
     "ios": "npx expo run:ios",
     "build": "npx expo export --platform web --output-dir dist",
-    "ci": "npm run lint && npm run typecheck && npm test -- --ci && npm run build",
+    "ci": "npm run lint && npm run typecheck && npm run android:version:check && npm test -- --ci && npm run build",
     "prepare": "husky",
     "commit": "npx git-cz || true",
     "lint-staged": "lint-staged"

--- a/scripts/check-android-version.mjs
+++ b/scripts/check-android-version.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function readJson(filePath) {
+  try {
+    const contents = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(contents);
+  } catch (error) {
+    console.error(`Failed to read JSON: ${filePath}`);
+    console.error(error.message);
+    process.exit(2);
+  }
+}
+
+function computeAndroidVersionCode(versionString) {
+  const base = (versionString || '0.0.0').split('-')[0];
+  const parts = base.split('.').map((n) => Number.parseInt(n, 10) || 0);
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  const patch = parts[2] ?? 0;
+  return major * 10000 + minor * 100 + patch;
+}
+
+function readGradleVersionCode(gradlePath) {
+  try {
+    const contents = fs.readFileSync(gradlePath, 'utf8');
+    const match = contents.match(/\bversionCode\s+(\d+)/);
+    if (!match) {
+      console.error(`versionCode not found in ${gradlePath}`);
+      process.exit(2);
+    }
+    return Number.parseInt(match[1], 10);
+  } catch (error) {
+    console.error(`Failed to read Gradle file: ${gradlePath}`);
+    console.error(error.message);
+    process.exit(2);
+  }
+}
+
+const repoRoot = process.cwd();
+const pkgPath = path.join(repoRoot, 'package.json');
+const gradlePath = path.join(repoRoot, 'android', 'app', 'build.gradle');
+
+const pkg = readJson(pkgPath);
+const version = pkg.version || '0.0.0';
+const expectedCode = computeAndroidVersionCode(version);
+const actualCode = readGradleVersionCode(gradlePath);
+
+if (expectedCode !== actualCode) {
+  console.error(
+    `Android versionCode mismatch. Expected ${expectedCode} from package.json version ${version}, but found ${actualCode} in android/app/build.gradle.\n` +
+      'Fix by syncing native files: npx expo prebuild -p android --non-interactive'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Android versionCode OK: ${actualCode} matches computed ${expectedCode} from package.json version ${version}`
+);


### PR DESCRIPTION
Adds versionCode check script, CI wiring, and non-interactive prebuild script. Also updates ESLint config for repo scripts and jest setup.