### PR TITLE
feat(ui): ADR-0004 branding and seed tap-to-copy (#229)

### DIFF
--- a/__tests__/app/classic.header.test.tsx
+++ b/__tests__/app/classic.header.test.tsx
@@ -3,18 +3,18 @@ import { render, screen } from '@testing-library/react-native';
 import ClassicScreen from '../../app/classic';
 
 describe('ClassicScreen header/footer', () => {
-  it('renders header with mode, difficulty, and time (no textual "Timer" label)', () => {
+  it('renders header with product title, mode/difficulty, and time (icon-only timer)', () => {
     render(<ClassicScreen />);
-    expect(screen.getAllByText(/Classic/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Mode:\s*Classic[\s\S]*Difficulty:\s*easy/)).toBeTruthy();
+    expect(screen.getByText('Ultimate Sudoku')).toBeTruthy();
+    expect(screen.getByText(/Classic\s*•\s*easy/)).toBeTruthy();
     const time = screen.getByLabelText('Elapsed time');
     expect(time).toBeTruthy();
   });
 
-  it('renders numeric seed in footer', () => {
+  it('renders numeric seed in footer (tappable to copy)', () => {
     render(<ClassicScreen />);
     const seedFooter = screen.getByLabelText('Seed footer');
-    expect(seedFooter).toHaveTextContent(/Seed:? \d+/);
+    expect(seedFooter).toHaveTextContent(/^\s*\d+\s*$/);
   });
 
   it('renders hearts-only lives with an accessible label (no textual "Lives" label)', () => {

--- a/__tests__/app/classic.test.tsx
+++ b/__tests__/app/classic.test.tsx
@@ -5,8 +5,8 @@ import ClassicScreen from '../../app/classic';
 describe('ClassicScreen', () => {
   it('renders header', () => {
     render(<ClassicScreen />);
-    expect(screen.getAllByText(/Classic/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Mode:\s*Classic[\s\S]*Difficulty:\s*easy/)).toBeTruthy();
+    expect(screen.getByText('Ultimate Sudoku')).toBeTruthy();
+    expect(screen.getByText(/Classic\s*•\s*easy/)).toBeTruthy();
     expect(screen.getByLabelText('Elapsed time')).toBeTruthy();
   });
 

--- a/__tests__/components/SeedFooter.test.tsx
+++ b/__tests__/components/SeedFooter.test.tsx
@@ -28,7 +28,7 @@ describe('SeedFooter', () => {
       </ThemeContext.Provider>,
     );
 
-    fireEvent.press(screen.getByLabelText('Copy seed'));
+    fireEvent.press(screen.getByLabelText('Seed footer'));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(seed));
     expect(await screen.findByLabelText('Seed copied')).toBeTruthy();

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -27,14 +27,14 @@ export default function Header({
   return (
     <View style={{ alignItems: 'center', marginBottom: 8 }}>
       <Text style={{ fontSize: 28, fontWeight: '700', marginBottom: 4, color: theme.foreground }}>
-        {mode}
+        Ultimate Sudoku
       </Text>
       {/* Row with centered mode/difficulty and right-aligned timer + icon-only pause */}
       <View
         style={{ width: boardPixelWidth ?? 36 * 9, position: 'relative', alignItems: 'center' }}
       >
         <Text style={{ fontSize: 12, opacity: 0.7, marginBottom: 2, color: theme.foreground }}>
-          Mode: {mode} • Difficulty: {difficulty}
+          {mode} • {difficulty}
         </Text>
         <Text
           accessibilityLabel="Elapsed time"

--- a/app/components/Numpad.tsx
+++ b/app/components/Numpad.tsx
@@ -74,9 +74,7 @@ export default function Numpad({
           );
         })}
       </View>
-      <Text style={{ fontSize: 12, opacity: 0.7, color: theme.foreground }}>
-        Long-press to lock a digit
-      </Text>
+      {/* Instructional text removed per ADR-0004; discoverability via icon and gesture */}
     </View>
   );
 }

--- a/app/components/SeedFooter.tsx
+++ b/app/components/SeedFooter.tsx
@@ -56,28 +56,23 @@ export default function SeedFooter({ seed }: SeedFooterProps) {
 
   return (
     <View style={{ marginTop: 12, alignItems: 'center' }}>
-      <Text
-        accessibilityLabel="Seed footer"
-        style={{ fontSize: 12, opacity: 0.6, color: theme.foreground }}
-      >
-        Seed: {seed}
-      </Text>
       <Pressable
         onPress={() => copySeedToClipboard(seed)}
         accessibilityRole="button"
-        accessibilityLabel="Copy seed"
-        accessibilityHint="Copies the puzzle seed to the clipboard"
-        style={{
-          marginTop: 6,
-          paddingHorizontal: 8,
-          paddingVertical: 4,
-          borderRadius: 4,
-          borderWidth: 1,
-          borderColor: theme.isDark ? '#374151' : '#d1d5db',
-          backgroundColor: theme.isDark ? '#0f1115' : '#ffffff',
-        }}
+        accessibilityLabel="Seed footer"
+        accessibilityHint="Tap to copy the puzzle seed to the clipboard"
+        style={{ paddingHorizontal: 4, paddingVertical: 2 }}
       >
-        <Text style={{ fontSize: 12, color: theme.foreground }}>Copy</Text>
+        <Text
+          style={{
+            fontSize: 12,
+            opacity: 0.6,
+            color: theme.foreground,
+            textDecorationLine: 'underline',
+          }}
+        >
+          {seed}
+        </Text>
       </Pressable>
       {copied ? (
         <Text

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.9 — 2025-08-19
 
-- Classic: Seed footer now supports copy-to-clipboard with confirmation toast (Issue #63).
+- Classic: Seed footer is tappable text (no button); copies with confirmation toast (Issue #63, ADR-0004).
 - Classic: Auto-pause implemented for AppState (native) and visibility/blur (web). Tagged BDD with @issue-105 (Issue #105).
 - Classic: Prevent default browser shortcuts/scroll for handled keys on web; add BDD @issue-106 and tests (Issue #106).
 - Classic: Persist notes mode, paused state, and locked digit across sessions; add BDD @issue-107 and tests (Issue #107).
@@ -10,7 +10,7 @@
 - Classic: Accessibility polish for cells' screen reader labels; updated BDD @issue-109 and added tests (Issue #109).
 - Classic: Numpad aligns to grid width; single-row layout; BDD/tests added (Issue #110).
 - Classic: Tools moved below numpad as icon-only buttons with a11y labels; BDD added (Issue #111).
-- Classic: Header shows hearts-only lives with accessible label; timer right-aligned (Issue #112).
+- Classic: Header shows product title "Ultimate Sudoku"; mode/difficulty without textual prefixes; hearts-only lives; timer right-aligned (Issue #112, ADR-0004).
 - Classic: Undo/Redo does not change lives; BDD tagged @issue-113 (Issue #113).
 - Classic: Highlight same digits across the board when a cell is selected; numpad key highlights for the active digit; tests added (Issue #115).
 - Engine: Add deterministic generator and solver; enforce unique solutions; tests added (#159).


### PR DESCRIPTION
- Header shows product title ‘Ultimate Sudoku’; mode/difficulty without prefixes\n- Remove numpad instruction; Seed is tappable to copy with confirmation\n- Tests and docs updated (ADR-0004)\n\nParent Epic: #227\nSub-issue: #229\n