### PR TITLE
docs(adr-0004): implementation notes for header/seed (#229)

### DIFF
--- a/docs/adr/0004-branding-and-labels.md
+++ b/docs/adr/0004-branding-and-labels.md
@@ -36,3 +36,8 @@ References
 - ADR-0003: UI Layout and Controls – icon-only tools, timer icon, and lock toggle.
 - MVP Spec: docs/product/ultimate-sudoku-mvp-v0.9.md
 - QA: docs/qa/features/\*.feature
+
+Implementation
+
+- Header reflects this ADR: `app/components/Header.tsx` renders the product title, shows mode/difficulty without prefixes, and right-aligns the timer with an icon-only pause/resume button and accessibility labels.
+- Seed footer reflects tap-to-copy behavior: `app/components/SeedFooter.tsx` renders the seed as tappable text with subtle affordance and confirmation feedback.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,3 +4,5 @@ This index lists the ADRs in this repository. New significant decisions should a
 
 - [ADR-0001: L5 Technique Scope (Finalized for MVP)](./0001-l5-techniques-scope.md)
 - [ADR-0002: Daily Determinism & No Reroll (Finalized for MVP)](./0002-daily-determinism-and-no-reroll.md)
+- [ADR-0003: UI Layout and Controls (Finalized for MVP)](./0003-ui-layout-and-controls.md)
+- [ADR-0004: Branding and Labels (Finalized for MVP)](./0004-branding-and-labels.md)


### PR DESCRIPTION
Adds Implementation guidance to ADR-0004 confirming that Header and SeedFooter reflect decisions.

Parent: #227
Refs: #229, #230