### PR TITLE
feat(daily): deterministic seed format and tier-based lives (#163)

### DIFF
--- a/app/daily.screen.tsx
+++ b/app/daily.screen.tsx
@@ -4,28 +4,39 @@ import Header from './components/Header';
 import Board from './components/Board';
 import SeedFooter from './components/SeedFooter';
 import { initializeGame } from './game/state';
-import type { Digit } from './game/types';
-import { generateDailyPuzzle } from './game/daily';
+import type { Digit, Difficulty } from './game/types';
+import { generateDailyPuzzle, createDailySeed, formatDailySeed } from './game/daily';
+
+function livesForDifficulty(d: Difficulty): number {
+  switch (d) {
+    case 'easy':
+      return 6;
+    case 'medium':
+      return 5;
+    case 'hard':
+      return 4;
+    case 'expert':
+      return 3;
+    case 'master':
+      return 2;
+    case 'extreme':
+      return 1;
+  }
+}
 
 export default function DailyScreen() {
-  const daily = useMemo(() => generateDailyPuzzle(new Date()), []);
-  const seed = useMemo(() => {
-    // Derive a stable seed string for footer from today's daily
-    // Use ISO date + count of givens to make it deterministic but simple
-    const d = new Date();
-    const y = d.getUTCFullYear();
-    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(d.getUTCDate()).padStart(2, '0');
-    return `${y}${m}${day}-D-${daily.givens.length}`;
-  }, [daily.givens.length]);
+  const today = useMemo(() => new Date(), []);
+  const seedObj = useMemo(() => createDailySeed(today), [today]);
+  const daily = useMemo(() => generateDailyPuzzle(today), [today]);
+  const seed = useMemo(() => formatDailySeed(seedObj), [seedObj]);
 
   const game = useMemo(
     () =>
       initializeGame(daily.givens as { row: number; col: number; value: Digit }[], {
-        difficulty: 'easy',
-        maxLives: 3,
+        difficulty: seedObj.difficulty,
+        maxLives: livesForDifficulty(seedObj.difficulty),
       }),
-    [daily.givens],
+    [daily.givens, seedObj.difficulty],
   );
 
   const boardPixelWidth = 9 * 44 + 12; // basic width similar to Classic defaults


### PR DESCRIPTION
Implements [#163](https://github.com/cynnix-inc/sudoku/issues/163) under Epic #16 (child of Epic #14).\n\nChanges:\n- Use createDailySeed/formatDailySeed for footer\n- Set difficulty + lives from daily seed tier\n- Keep deterministic generation via engine\n\nQuality:\n- Lint, typecheck, tests, build green locally\n\nDocs:\n- Matches MVP v0.9 §2.4; no ADR change required