### PR TITLE
feat(daily): implement weekly difficulty mixes A–D and seed format (#38)

### DIFF
--- a/__tests__/game/daily.test.ts
+++ b/__tests__/game/daily.test.ts
@@ -10,7 +10,7 @@ describe('daily module (#163)', () => {
     const d = new Date(Date.UTC(2025, 8, 21));
     const seed = createDailySeed(d);
     const fmt = formatDailySeed(seed);
-    expect(fmt).toMatch(/^\d{8}-[A-Z]-[a-z]+$/);
+    expect(fmt).toMatch(/^\d{8}-[A-D]-[a-z]+$/);
   });
 
   it('rotates difficulty weekly and is deterministic per date', () => {

--- a/app/game/daily/index.ts
+++ b/app/game/daily/index.ts
@@ -3,21 +3,62 @@ import { generatePuzzle } from '../engine/generator';
 
 export type DailySeed = {
   utcDate: string; // YYYYMMDD
-  patternId: string; // single uppercase letter A-Z
+  patternId: string; // single uppercase letter A-D (weekly pattern mix)
   difficulty: Difficulty; // lowercase tier per app/game/types
 };
+
+// Weekly difficulty mixes (Monday → Sunday)
+// Pattern A is the base; B/C/D are rotations of the base for variety.
+const BASE_WEEK_MIX: Difficulty[] = [
+  'easy', // Mon
+  'medium', // Tue
+  'hard', // Wed
+  'expert', // Thu
+  'master', // Fri
+  'extreme', // Sat
+  'medium', // Sun (cool-down)
+];
+
+const WEEK_MIXES: Difficulty[][] = [
+  BASE_WEEK_MIX,
+  // rotate by 1..3 to produce B, C, D
+  rotate(BASE_WEEK_MIX, 1),
+  rotate(BASE_WEEK_MIX, 2),
+  rotate(BASE_WEEK_MIX, 3),
+];
+
+function rotate<T>(arr: readonly T[], by: number): T[] {
+  const n = arr.length;
+  const k = ((by % n) + n) % n;
+  return [...arr.slice(k), ...arr.slice(0, k)];
+}
+
+function getIsoWeekIndex(date: Date): number {
+  const y = date.getUTCFullYear();
+  const jan4 = new Date(Date.UTC(y, 0, 4));
+  const week1Monday = new Date(jan4.getTime() - ((jan4.getUTCDay() + 6) % 7) * 86400000);
+  return Math.floor((date.getTime() - week1Monday.getTime()) / (7 * 86400000));
+}
+
+function getUtcWeekdayIndex(date: Date): number {
+  // Convert JS Sunday=0..Saturday=6 to ISO Monday=0..Sunday=6
+  const d = date.getUTCDay();
+  return (d + 6) % 7;
+}
+
+export function getPatternIdForDate(date: Date): 'A' | 'B' | 'C' | 'D' {
+  const weekIndex = getIsoWeekIndex(date);
+  const idx = ((weekIndex % 4) + 4) % 4;
+  return String.fromCharCode('A'.charCodeAt(0) + idx) as 'A' | 'B' | 'C' | 'D';
+}
 
 export function createDailySeed(date: Date): DailySeed {
   const y = date.getUTCFullYear();
   const m = String(date.getUTCMonth() + 1).padStart(2, '0');
   const d = String(date.getUTCDate()).padStart(2, '0');
   const utcDate = `${y}${m}${d}`;
-  // Rotate a simple pattern weekly: A..Z cycling based on ISO week number
-  const jan4 = new Date(Date.UTC(y, 0, 4));
-  const week1Monday = new Date(jan4.getTime() - ((jan4.getUTCDay() + 6) % 7) * 86400000);
-  const weekIndex = Math.floor((date.getTime() - week1Monday.getTime()) / (7 * 86400000));
-  const patternId = String.fromCharCode('A'.charCodeAt(0) + (weekIndex % 26));
-  const difficulty = difficultyForDate(date);
+  const patternId = getPatternIdForDate(date);
+  const difficulty = difficultyForDate(date); // derived from weekly mix + weekday
   return { utcDate, patternId, difficulty };
 }
 
@@ -26,11 +67,11 @@ export function formatDailySeed(seed: DailySeed): string {
 }
 
 export function difficultyForDate(date: Date): Difficulty {
-  // Cycle tiers weekly: easy, medium, hard, expert, master, extreme
-  const tiers: Difficulty[] = ['easy', 'medium', 'hard', 'expert', 'master', 'extreme'];
-  const start = Date.UTC(2025, 0, 6); // Monday baseline for rotation
-  const weekIndex = Math.floor((date.getTime() - start) / (7 * 86400000));
-  return tiers[((weekIndex % tiers.length) + tiers.length) % tiers.length]!;
+  const weekIndex = getIsoWeekIndex(date);
+  const patternIdx = ((weekIndex % WEEK_MIXES.length) + WEEK_MIXES.length) % WEEK_MIXES.length;
+  const weekdayIdx = getUtcWeekdayIndex(date);
+  const mix = WEEK_MIXES[patternIdx]!;
+  return mix[weekdayIdx]!;
 }
 
 export function generateDailyPuzzle(date: Date) {


### PR DESCRIPTION
Parent: #15\n\nImplements ADR-0002 weekly difficulty patterns (A–D) and constrains patternId to A–D. Updates tests for deterministic seed format.\n\n- Docs: references docs/adr/0002-daily-determinism-and-no-reroll.md\n- QA: aligns with docs/qa/features/02-modes-daily.feature deterministic scenario\n\nCI: lint, typecheck, tests all green locally.\n\nCloses #38