### PR TITLE
feat(ui): seed value tap-to-copy with hover/focus affordance and a11y (#204)

### DIFF
--- a/__tests__/app/classic.header.test.tsx
+++ b/__tests__/app/classic.header.test.tsx
@@ -13,7 +13,7 @@ describe('ClassicScreen header/footer', () => {
 
   it('renders numeric seed in footer (tappable to copy)', () => {
     render(<ClassicScreen />);
-    const seedFooter = screen.getByLabelText('Seed footer');
+    const seedFooter = screen.getByLabelText('Copy seed');
     expect(seedFooter).toHaveTextContent(/^\s*\d+\s*$/);
   });
 

--- a/__tests__/components/SeedFooter.test.tsx
+++ b/__tests__/components/SeedFooter.test.tsx
@@ -28,7 +28,7 @@ describe('SeedFooter', () => {
       </ThemeContext.Provider>,
     );
 
-    fireEvent.press(screen.getByLabelText('Seed footer'));
+    fireEvent.press(screen.getByLabelText('Copy seed'));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(seed));
     expect(await screen.findByLabelText('Seed copied')).toBeTruthy();

--- a/app/components/SeedFooter.tsx
+++ b/app/components/SeedFooter.tsx
@@ -12,6 +12,8 @@ type MinimalNavigator = { clipboard?: MinimalClipboard };
 export default function SeedFooter({ seed }: SeedFooterProps) {
   const theme = useContext(ThemeContext);
   const [copied, setCopied] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
 
   async function copySeedToClipboard(text: string) {
     try {
@@ -59,16 +61,29 @@ export default function SeedFooter({ seed }: SeedFooterProps) {
       <Pressable
         onPress={() => copySeedToClipboard(seed)}
         accessibilityRole="button"
-        accessibilityLabel="Seed footer"
+        accessibilityLabel="Copy seed"
         accessibilityHint="Tap to copy the puzzle seed to the clipboard"
-        style={{ paddingHorizontal: 4, paddingVertical: 2 }}
+        onHoverIn={() => setHovered(true)}
+        onHoverOut={() => setHovered(false)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        style={{
+          paddingHorizontal: 4,
+          paddingVertical: 2,
+          // Web affordances
+          cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+          outlineStyle: 'solid',
+          outlineWidth: focused ? 2 : 0,
+          outlineColor: focused ? (theme.isDark ? '#60a5fa' : '#2563eb') : 'transparent',
+          borderRadius: 4,
+        }}
       >
         <Text
           style={{
             fontSize: 12,
-            opacity: 0.6,
+            opacity: hovered || focused ? 0.8 : 0.6,
             color: theme.foreground,
-            textDecorationLine: 'none',
+            textDecorationLine: hovered || focused ? 'underline' : 'none',
           }}
         >
           {seed}


### PR DESCRIPTION
Parent: #201\n\nImplements Seed tap-to-copy via value with subtle hover/focus affordance and improved accessibility labels.\n\n- ADR: docs/adr/0004-branding-and-labels.md\n- Tests updated: SeedFooter and Classic header\n\nCloses #204