### PR TITLE
test(ui): no Mode/Difficulty labels in header (ADR-0004) (#205)

### DIFF
--- a/__tests__/app/classic.header.test.tsx
+++ b/__tests__/app/classic.header.test.tsx
@@ -37,4 +37,10 @@ describe('ClassicScreen header/footer', () => {
     // Now offset by 24 to make room for the pause icon
     expect(time.props.style.right).toBe(24);
   });
+
+  it('does not render textual prefixes for Mode/Difficulty (ADR-0004)', () => {
+    render(<ClassicScreen />);
+    expect(screen.queryByText(/\bMode:/i)).toBeNull();
+    expect(screen.queryByText(/\bDifficulty:/i)).toBeNull();
+  });
 });


### PR DESCRIPTION
Parent: #201\n\nAdds tests to ensure header renders without textual prefixes 'Mode:' and 'Difficulty:' per ADR-0004.\n\n- ADR: docs/adr/0004-branding-and-labels.md\n- Tests: __tests__/app/classic.header.test.tsx\n\nCloses #205