### PR TITLE
docs(adr): adr-0006 hybrid spa navigation (proposed) (#278)

### DIFF
--- a/docs/adr/0006-hybrid-spa-navigation.md
+++ b/docs/adr/0006-hybrid-spa-navigation.md
@@ -1,0 +1,36 @@
+# ADR-0006: Hybrid SPA Navigation (Router infra kept; state-based game screens)
+
+Date: 2025-08-26
+
+Status: Proposed
+
+Context
+
+- The app currently uses Expo Router/React Navigation patterns suitable for multi-screen apps.
+- Product direction prefers a single-page-app feel for gameplay: switching modes (e.g., Classic, Daily) should not require distinct URL routes.
+- We still want router infrastructure for web deep links (e.g., help/about) and future growth, but gameplay transitions should be instantaneous without route churn.
+
+Decision
+
+1. Keep router infrastructure for non-game surfaces and base app shell.
+2. Represent gameplay screens (Classic, Daily, Archives) via application state rather than URL routes.
+3. Remove public URL routes for gameplay (e.g., no `/daily` route); navigation between gameplay screens is handled within the app state/store.
+4. Provide a not-found boundary for unknown routes with a minimal SPA-friendly page.
+
+Consequences
+
+- Web feels faster with fewer hard route transitions during gameplay.
+- Deep links remain viable for documentation/help and future non-game pages.
+- Tests, docs, and QA features must reflect no public gameplay URLs.
+
+Implementation Notes
+
+- Index screen selects the current gameplay screen via state and renders the corresponding component.
+- Add a not-found boundary component for router fallbacks.
+- Update tests to remove assumptions about `/daily` or similar gameplay URL routes.
+
+References
+
+- Product: docs/product/ultimate-sudoku-mvp-v0.9.md
+- QA: docs/qa/features/08-navigation-help.feature
+- Related Issues: #277, #278, #279, #280, #281

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,3 +6,4 @@ This index lists the ADRs in this repository. New significant decisions should a
 - [ADR-0002: Daily Determinism & No Reroll (Finalized for MVP)](./0002-daily-determinism-and-no-reroll.md)
 - [ADR-0003: UI Layout and Controls (Finalized for MVP)](./0003-ui-layout-and-controls.md)
 - [ADR-0004: Branding and Labels (Finalized for MVP)](./0004-branding-and-labels.md)
+- [ADR-0006: Hybrid SPA Navigation (Proposed)](./0006-hybrid-spa-navigation.md)


### PR DESCRIPTION
Parent: #201\n\nAdds ADR-0006: Hybrid SPA navigation (router infra kept; state-based game screens).\n\n- Context and decision documented\n- Consequences and implementation notes\n- References to related issues and QA\n\nCloses #278