### PR TITLE
docs(qa): update navigation feature for spa model (no daily route) (#279)

### DIFF
--- a/docs/qa/features/08-navigation-help.feature
+++ b/docs/qa/features/08-navigation-help.feature
@@ -8,17 +8,24 @@ Feature: Navigation and Help/About (MVP)
     Then the respective screen opens
 
   @mvp @nav @daily
-  Scenario: Daily route opens the Daily screen (#260)
+  Scenario: Daily route is not available (SPA model) (#279)
     Given I navigate to "/daily"
+    Then I see a friendly not-found message
+    And I see a link to return Home
+
+  @mvp @nav @daily
+  Scenario: Daily opens from Home without changing URL (#279)
+    Given I am on the home screen
+    When I select Daily
     Then the Daily screen opens
 
   @mvp @nav @notfound
-  Scenario: Not-found page is friendly and does not expose site map (#260)
+  Scenario: Not-found page is friendly and does not expose site map (#279)
     Given I navigate to "/this/route/does-not-exist"
     Then I see a friendly not-found message
     And I see a link to return Home
     And the full site map is not exposed
-    # Tracking: Daily route wiring / not-found boundary (#260)
+    # Tracking: SPA not-found boundary (#279)
 
   @mvp @nav
   Scenario: Home button returns to main


### PR DESCRIPTION
Parent: #201\n\nUpdates QA navigation feature for SPA model per ADR-0006: removes reliance on /daily URL, adds not-found expectations for /daily and unknown routes, and ensures Daily opens from Home without URL change.\n\nCloses #279