### PR TITLE
feat(nav): add SPA-friendly not-found boundary screen and test (#281)

### DIFF
--- a/__tests__/app/not-found.test.tsx
+++ b/__tests__/app/not-found.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import NotFoundScreen from '../../app/+not-found';
+
+describe('NotFoundScreen', () => {
+  it('shows friendly not-found message and a Home action', () => {
+    render(<NotFoundScreen />);
+    expect(screen.getByText(/page not found/i)).toBeTruthy();
+    expect(screen.getByLabelText('Go home')).toBeTruthy();
+  });
+});

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { ThemeContext } from './_layout';
+import { router } from 'expo-router';
+
+export default function NotFoundScreen() {
+  const theme = useContext(ThemeContext);
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+      <Text
+        accessibilityRole="header"
+        style={{ fontSize: 24, fontWeight: '700', marginBottom: 12, color: theme.foreground }}
+      >
+        Page not found
+      </Text>
+      <Text
+        style={{
+          fontSize: 14,
+          opacity: 0.8,
+          textAlign: 'center',
+          marginBottom: 16,
+          color: theme.foreground,
+        }}
+      >
+        The page you’re looking for doesn’t exist. You can return to Home.
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Go home"
+        onPress={() => router.replace('/')}
+        style={{
+          paddingHorizontal: 12,
+          paddingVertical: 8,
+          borderRadius: 8,
+          borderWidth: 1,
+          borderColor: theme.foreground,
+        }}
+      >
+        <Text style={{ color: theme.foreground, fontWeight: '600' }}>Return Home</Text>
+      </Pressable>
+    </View>
+  );
+}


### PR DESCRIPTION
Parent: #201\n\nAdds a minimal, friendly not-found boundary (pp/+not-found.tsx) with a link back to Home. Includes unit test.\n\n- ADR: docs/adr/0006-hybrid-spa-navigation.md\n- QA: docs/qa/features/08-navigation-help.feature updated in #279\n\nCloses #281