### PR TITLE
test(nav): update home SPA navigation tests for Classic/Daily (#280)

### DIFF
--- a/__tests__/app/index.test.tsx
+++ b/__tests__/app/index.test.tsx
@@ -1,15 +1,31 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
 import IndexScreen from '../../app/index';
 
 jest.mock('expo-router', () => ({
   Link: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-describe('IndexScreen', () => {
-  it('renders links', () => {
+describe('IndexScreen (SPA navigation)', () => {
+  it('renders play options', () => {
     render(<IndexScreen />);
     expect(screen.getByText('Play Classic 9×9')).toBeTruthy();
+    expect(screen.getByText('Play Daily')).toBeTruthy();
+  });
+
+  it('navigates to Classic via state and back home', () => {
+    render(<IndexScreen />);
+    fireEvent.press(screen.getByLabelText('Go to Classic'));
+    expect(screen.getByLabelText('New game')).toBeTruthy();
+    fireEvent.press(screen.getByLabelText('Return Home'));
+    expect(screen.getByText('Play Classic 9×9')).toBeTruthy();
+  });
+
+  it('navigates to Daily via state and back home', () => {
+    render(<IndexScreen />);
+    fireEvent.press(screen.getByLabelText('Go to Daily'));
+    expect(screen.queryByLabelText('New game')).toBeNull();
+    fireEvent.press(screen.getByLabelText('Return Home'));
     expect(screen.getByText('Play Daily')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Parent: #201\n\nUpdates home screen tests to validate SPA state navigation to Classic and Daily, and returning Home.\n\n- Files: __tests__/app/index.test.tsx\n- All checks green locally\n\nCloses #280