### PR TITLE
feat(storage): settings persistence service with per-field timestamps (#48)

### DIFF
--- a/__tests__/services/settings.test.ts
+++ b/__tests__/services/settings.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach } from '@jest/globals';
+import { __TEST_ONLY__clearProgress } from '../../app/services/storage';
+import {
+  loadSettings,
+  saveSettings,
+  updateSettings,
+  settingsKey,
+  type SettingsData,
+} from '../../app/services/settings';
+
+describe('services/settings', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress(settingsKey());
+  });
+
+  it('loads defaults when none saved', async () => {
+    const loaded = await loadSettings();
+    expect(loaded.settingsVersion).toBe(1);
+    expect(loaded.values.theme).toBe('system');
+  });
+
+  it('saves and loads roundtrip', async () => {
+    const data: SettingsData = await loadSettings();
+    data.values.theme = 'dark';
+    await saveSettings(data);
+    const again = await loadSettings();
+    expect(again.values.theme).toBe('dark');
+  });
+
+  it('updates single field and stamps timestamp', async () => {
+    const before = await loadSettings();
+    expect(before.timestamps['autoAdvance']).toBeUndefined();
+    const fixedTime = 1111111111111;
+    const after = await updateSettings('autoAdvance', false, fixedTime);
+    expect(after.values.autoAdvance).toBe(false);
+    expect(after.timestamps['autoAdvance']).toBe(fixedTime);
+    const reloaded = await loadSettings();
+    expect(reloaded.values.autoAdvance).toBe(false);
+    expect(reloaded.timestamps['autoAdvance']).toBe(fixedTime);
+  });
+});

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -1,0 +1,84 @@
+import { loadProgress, saveProgress } from './storage';
+
+export type SettingsVersion = 1;
+
+export type SettingsTimestamps = Partial<Record<keyof SettingsData['values'], number>> & {
+  updatedAt?: number;
+};
+
+export type SettingsValues = {
+  errorHighlighting: boolean;
+  autoCandidates: 'on' | 'off' | 'default';
+  autoAdvance: boolean;
+  haptics: boolean;
+  theme: 'system' | 'light' | 'dark';
+  accentColor: string;
+  gridSize: number; // 0..2 small/medium/large
+  inputSize: number; // 0..2
+  notesSize: number; // 0..2
+  calendarWeekStartsOn: 'mon' | 'sun';
+  calendarFilter: 'all' | 'completed' | 'incomplete';
+};
+
+export type SettingsData = {
+  settingsVersion: SettingsVersion;
+  values: SettingsValues;
+  timestamps: SettingsTimestamps;
+  lastSyncAttempt?: number;
+};
+
+const SETTINGS_KEY = 'sudoku-settings';
+
+const DEFAULT_SETTINGS: SettingsData = {
+  settingsVersion: 1 as const,
+  values: {
+    errorHighlighting: true,
+    autoCandidates: 'default',
+    autoAdvance: true,
+    haptics: true,
+    theme: 'system',
+    accentColor: '#22c55e',
+    gridSize: 1,
+    inputSize: 1,
+    notesSize: 1,
+    calendarWeekStartsOn: 'mon',
+    calendarFilter: 'all',
+  },
+  timestamps: {},
+};
+
+export async function loadSettings(): Promise<SettingsData> {
+  const existing = await loadProgress<SettingsData>(SETTINGS_KEY);
+  if (!existing) return { ...DEFAULT_SETTINGS };
+  // Shallow migrate: ensure new fields exist without dropping user values
+  const merged: SettingsData = {
+    settingsVersion: 1 as const,
+    values: { ...DEFAULT_SETTINGS.values, ...existing.values },
+    timestamps: { ...existing.timestamps },
+    lastSyncAttempt: existing.lastSyncAttempt,
+  };
+  return merged;
+}
+
+export async function saveSettings(next: SettingsData): Promise<void> {
+  await saveProgress(SETTINGS_KEY, next);
+}
+
+export async function updateSettings<K extends keyof SettingsValues>(
+  key: K,
+  value: SettingsValues[K],
+  updatedAt: number = Date.now(),
+): Promise<SettingsData> {
+  const current = await loadSettings();
+  const next: SettingsData = {
+    ...current,
+    values: { ...current.values, [key]: value },
+    timestamps: { ...current.timestamps, [key]: updatedAt, updatedAt },
+  };
+  await saveSettings(next);
+  return next;
+}
+
+export function settingsKey(): string {
+  return SETTINGS_KEY;
+}


### PR DESCRIPTION
Implements settings persistence per MVP docs.

- Adds app/services/settings.ts with typed values, per-field timestamps, settingsVersion, lastSyncAttempt
- Adds tests __tests__/services/settings.test.ts
- No UI wiring yet; this unblocks [Settings] UI (#61) and sync conflict rules (#175)

Docs/ADRs:
- References: docs/product/ultimate-sudoku-mvp-v0.9.md (storage keys spec)

Verification:
- npm run ci (lint, typecheck, tests, build) all green

Closes #48