### PR TITLE
feat(stats): schema v2 with daily results, lastCalculated, and no-hint gating (#51)

### DIFF
--- a/__tests__/services/stats.service.test.ts
+++ b/__tests__/services/stats.service.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach } from '@jest/globals';
+import { __TEST_ONLY__clearProgress } from '../../app/services/storage';
+import { loadStats, recordResult, recordDailyResult } from '../../app/services/stats';
+
+describe('services/stats (#51)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress('sudoku-stats');
+  });
+
+  it('updates best times on win', async () => {
+    await recordResult('easy', 'win', 120);
+    const stats = await loadStats();
+    expect(stats?.bestTimeByDifficulty['easy']).toBe(120);
+  });
+
+  it('does not update best time when hints used', async () => {
+    await recordResult('easy', 'win', 150, { usedHints: true });
+    const stats = await loadStats();
+    expect(stats?.bestTimeByDifficulty['easy']).toBeUndefined();
+  });
+
+  it('records daily results and caps recent list', async () => {
+    for (let i = 0; i < 65; i++) {
+      const day = 20240101 + i;
+      await recordDailyResult(String(day), 'medium', 'win', 200 + i, false);
+    }
+    const stats = await loadStats();
+    expect(stats).toBeTruthy();
+    const recent = (stats as NonNullable<typeof stats>).recentDailyResults;
+    expect(recent.length).toBeLessThanOrEqual(60);
+    const first = recent[0];
+    if (!first) throw new Error('recentDailyResults empty');
+    expect(first.date).toBe(String(20240101 + 64));
+  });
+});

--- a/app/services/stats.ts
+++ b/app/services/stats.ts
@@ -3,53 +3,129 @@ import { loadProgress, saveProgress } from './storage';
 
 export type StatsResult = 'win' | 'loss';
 
+export type DailyResult = {
+  date: string; // YYYYMMDD (UTC)
+  result: StatsResult;
+  seconds: number;
+  usedHints: boolean;
+};
+
 export type StatsData = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   totals: {
     played: number;
     wins: number;
     losses: number;
   };
   bestTimeByDifficulty: Partial<Record<GameConfig['difficulty'], number>>;
+  recentDailyResults: DailyResult[];
+  lastCalculated: number; // epoch ms
 };
 
 const STATS_KEY = 'sudoku-stats';
+const RECENT_DAILY_MAX = 60;
 
 export async function loadStats(): Promise<StatsData | null> {
-  return loadProgress<StatsData>(STATS_KEY);
+  const loaded = await loadProgress<unknown>(STATS_KEY);
+  if (!loaded) return null;
+
+  type StatsDataV1 = {
+    schemaVersion: 1;
+    totals?: { played: number; wins: number; losses: number };
+    bestTimeByDifficulty?: Partial<Record<GameConfig['difficulty'], number>>;
+  };
+
+  function isStatsV1(data: unknown): data is StatsDataV1 {
+    if (!data || typeof data !== 'object') return false;
+    const maybe = data as { schemaVersion?: unknown };
+    return maybe.schemaVersion === 1;
+  }
+
+  // Migrate v1 -> v2 (add recentDailyResults, lastCalculated)
+  if (isStatsV1(loaded)) {
+    const migrated: StatsData = {
+      schemaVersion: 2 as const,
+      totals: loaded.totals ?? { played: 0, wins: 0, losses: 0 },
+      bestTimeByDifficulty: loaded.bestTimeByDifficulty ?? {},
+      recentDailyResults: [],
+      lastCalculated: Date.now(),
+    };
+    return migrated;
+  }
+  return loaded as StatsData;
 }
 
 export async function saveStats(data: StatsData): Promise<void> {
   await saveProgress(STATS_KEY, data);
 }
 
+type RecordOptions = {
+  usedHints?: boolean;
+  isDaily?: boolean;
+  dateUTC?: string; // YYYYMMDD
+};
+
 export async function recordResult(
   difficulty: GameConfig['difficulty'],
   result: StatsResult,
   secondsElapsed: number,
+  options?: RecordOptions,
 ): Promise<void> {
   const existing = (await loadStats()) ?? {
-    schemaVersion: 1 as const,
+    schemaVersion: 2 as const,
     totals: { played: 0, wins: 0, losses: 0 },
     bestTimeByDifficulty: {},
+    recentDailyResults: [],
+    lastCalculated: 0,
   };
 
+  const usedHints = options?.usedHints === true;
+  const isDaily = options?.isDaily === true && typeof options?.dateUTC === 'string';
+
   const next: StatsData = {
-    schemaVersion: 1 as const,
+    schemaVersion: 2 as const,
     totals: {
       played: existing.totals.played + 1,
       wins: existing.totals.wins + (result === 'win' ? 1 : 0),
       losses: existing.totals.losses + (result === 'loss' ? 1 : 0),
     },
     bestTimeByDifficulty: { ...existing.bestTimeByDifficulty },
+    recentDailyResults: [...existing.recentDailyResults],
+    lastCalculated: Date.now(),
   };
 
-  if (result === 'win') {
+  if (result === 'win' && !usedHints) {
     const currentBest = next.bestTimeByDifficulty[difficulty];
     if (typeof currentBest !== 'number' || secondsElapsed < currentBest) {
       next.bestTimeByDifficulty[difficulty] = secondsElapsed;
     }
   }
 
+  if (isDaily) {
+    next.recentDailyResults.unshift({
+      date: options!.dateUTC!,
+      result,
+      seconds: secondsElapsed,
+      usedHints,
+    });
+    if (next.recentDailyResults.length > RECENT_DAILY_MAX) {
+      next.recentDailyResults.length = RECENT_DAILY_MAX;
+    }
+  }
+
   await saveStats(next);
+}
+
+export async function recordDailyResult(
+  dateUTC: string,
+  difficulty: GameConfig['difficulty'],
+  result: StatsResult,
+  secondsElapsed: number,
+  usedHints: boolean,
+): Promise<void> {
+  await recordResult(difficulty, result, secondsElapsed, {
+    usedHints,
+    isDaily: true,
+    dateUTC,
+  });
 }


### PR DESCRIPTION
Implements stats persistence per MVP docs.\n\n- Updates pp/services/stats.ts to schema v2: totals, best time gating (no-hint), recent daily results (cap 60), lastCalculated.\n- Adds tests __tests__/services/stats.service.test.ts.\n\nVerification:\n- npm run ci (lint, typecheck, tests, build) all green locally\n\nDocs:\n- References specs in docs/product/ultimate-sudoku-mvp-v0.9.md.\n\nCloses #51