### PR TITLE
feat(auth): email/password sign-in, sign-out, and session helpers (#54)

### DIFF
--- a/__tests__/services/auth.test.ts
+++ b/__tests__/services/auth.test.ts
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+jest.mock('@supabase/supabase-js', () => {
+  const auth = {
+    signInWithPassword: jest.fn(async ({ email, password }) => {
+      if (email === 'ok@example.com' && password === 'pass') {
+        return { data: { user: { id: 'u_123', email } }, error: null };
+      }
+      return { data: { user: null }, error: { message: 'Invalid credentials' } };
+    }),
+    signOut: jest.fn(async () => ({ error: null })),
+    getUser: jest.fn(async () => ({
+      data: { user: { id: 'u_123', email: 'ok@example.com' } },
+      error: null,
+    })),
+  };
+  const createClient = jest.fn(() => ({ auth }));
+  return { createClient };
+});
+
+describe('auth service (#54)', () => {
+  it('signs in with email/password and returns user id', async () => {
+    process.env['EXPO_PUBLIC_SUPABASE_URL'] = 'https://example.supabase.co';
+    process.env['EXPO_PUBLIC_SUPABASE_ANON_KEY'] = 'anon';
+    jest.resetModules();
+    const { signInWithEmail } = require('../../app/services/auth');
+    const res = await signInWithEmail('ok@example.com', 'pass');
+    expect(res.userId).toBe('u_123');
+    expect(res.error).toBeUndefined();
+  });
+
+  it('fails sign in with invalid credentials', async () => {
+    process.env['EXPO_PUBLIC_SUPABASE_URL'] = 'https://example.supabase.co';
+    process.env['EXPO_PUBLIC_SUPABASE_ANON_KEY'] = 'anon';
+    jest.resetModules();
+    const { signInWithEmail } = require('../../app/services/auth');
+    const res = await signInWithEmail('bad@example.com', 'nope');
+    expect(res.userId).toBeNull();
+    expect(res.error).toBeTruthy();
+  });
+
+  it('getCurrentUser returns null when env missing', async () => {
+    delete process.env['EXPO_PUBLIC_SUPABASE_URL'];
+    delete process.env['EXPO_PUBLIC_SUPABASE_ANON_KEY'];
+    (process as unknown as { env: Record<string, string | undefined> }).env['NODE_ENV'] =
+      'development';
+    jest.resetModules();
+    const { getCurrentUser } = require('../../app/services/auth');
+    const u = await getCurrentUser();
+    expect(u).toBeNull();
+  });
+});

--- a/app/services/auth.ts
+++ b/app/services/auth.ts
@@ -1,0 +1,36 @@
+import { supabase } from './supabase';
+
+export type AuthUser = {
+  id: string;
+  email?: string | null;
+};
+
+export type SignInResult = {
+  userId: string | null;
+  error?: string;
+};
+
+export async function signInWithEmail(email: string, password: string): Promise<SignInResult> {
+  if (!supabase) {
+    return { userId: null, error: 'Auth disabled: missing Supabase env' };
+  }
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) return { userId: null, error: error.message };
+  return { userId: data.user?.id ?? null };
+}
+
+export async function signOut(): Promise<{ ok: boolean; error?: string }> {
+  if (!supabase) return { ok: true };
+  const { error } = await supabase.auth.signOut();
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}
+
+export async function getCurrentUser(): Promise<AuthUser | null> {
+  if (!supabase) return null;
+  const { data, error } = await supabase.auth.getUser();
+  if (error) return null;
+  const user = data.user;
+  if (!user) return null;
+  return { id: user.id, email: (user as { email?: string | null }).email };
+}


### PR DESCRIPTION
Adds pp/services/auth.ts with email/password sign-in, sign-out, and current session helpers.\nTests: __tests__/services/auth.test.ts.\nVerification: local CI (lint, typecheck, tests, build) green.\nDocs: relies on existing Supabase env handling in pp/services/supabase.ts.\n\nCloses #54