### PR TITLE
feat(storage): unified sudoku-* key helpers and namespace clearing (#169)

### DIFF
--- a/__tests__/services/storage.keys.test.ts
+++ b/__tests__/services/storage.keys.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach } from '@jest/globals';
+import {
+  storageKeys,
+  clearNamespace,
+  clearAllSudoku,
+  __TEST_ONLY__clearProgress,
+  saveProgress,
+  loadProgress,
+} from '../../app/services/storage';
+
+describe('storage keys & namespace clearing (#169)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress();
+  });
+
+  it('produces stable keys for settings, stats, and daily', () => {
+    expect(storageKeys.settings()).toBe('sudoku-settings');
+    expect(storageKeys.stats()).toBe('sudoku-stats');
+    expect(storageKeys.daily('20250101')).toBe('sudoku-daily-20250101');
+  });
+
+  it('clears only the targeted namespace when provided', async () => {
+    await saveProgress(storageKeys.settings(), { a: 1 });
+    await saveProgress(storageKeys.stats(), { b: 2 });
+    await saveProgress(storageKeys.daily('20250101'), { c: 3 });
+
+    clearNamespace('stats');
+
+    const s = await loadProgress(storageKeys.settings());
+    const st = await loadProgress(storageKeys.stats());
+    const d = await loadProgress(storageKeys.daily('20250101'));
+    expect(s).not.toBeNull();
+    expect(st).toBeNull();
+    expect(d).not.toBeNull();
+  });
+
+  it('clears all sudoku-* keys when namespace omitted', async () => {
+    await saveProgress(storageKeys.settings(), { a: 1 });
+    await saveProgress(storageKeys.stats(), { b: 2 });
+    await saveProgress(storageKeys.daily('20250101'), { c: 3 });
+
+    clearAllSudoku();
+
+    const s = await loadProgress(storageKeys.settings());
+    const st = await loadProgress(storageKeys.stats());
+    const d = await loadProgress(storageKeys.daily('20250101'));
+    expect(s).toBeNull();
+    expect(st).toBeNull();
+    expect(d).toBeNull();
+  });
+});

--- a/app/services/storage.ts
+++ b/app/services/storage.ts
@@ -30,6 +30,56 @@ export async function loadProgress<T>(key: string): Promise<T | null> {
   return null;
 }
 
+// Unified storage key helpers for the Sudoku app namespace
+const STORAGE_PREFIX = 'sudoku-';
+
+export const storageKeys = {
+  settings(): string {
+    return `${STORAGE_PREFIX}settings`;
+  },
+  stats(): string {
+    return `${STORAGE_PREFIX}stats`;
+  },
+  daily(utcDate: string): string {
+    return `${STORAGE_PREFIX}daily-${utcDate}`;
+  },
+};
+
+function keyMatchesNamespace(key: string, namespace?: string): boolean {
+  if (!key.startsWith(STORAGE_PREFIX)) return false;
+  if (!namespace) return true; // entire sudoku-* namespace
+  return key.startsWith(`${STORAGE_PREFIX}${namespace}`);
+}
+
+// Clear keys in the sudoku namespace. If namespace omitted, clears all sudoku-* keys.
+export function clearNamespace(namespace?: 'settings' | 'stats' | 'daily' | string): void {
+  // memory store
+  for (const key of Array.from(memoryStore.keys())) {
+    if (keyMatchesNamespace(key, namespace)) {
+      memoryStore.delete(key);
+    }
+  }
+  // localStorage
+  if (typeof window !== 'undefined' && 'localStorage' in window && window.localStorage) {
+    try {
+      // Iterate backwards because removing items mutates length
+      for (let i = window.localStorage.length - 1; i >= 0; i--) {
+        const k = window.localStorage.key(i);
+        if (k && keyMatchesNamespace(k, namespace)) {
+          window.localStorage.removeItem(k);
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// Clear all sudoku-* keys across stores
+export function clearAllSudoku(): void {
+  clearNamespace(undefined);
+}
+
 // Test-only helpers to avoid cross-test leakage when using storage fallbacks or jsdom localStorage
 export function __TEST_ONLY__clearMemoryStore(): void {
   memoryStore.clear();


### PR DESCRIPTION
Adds unified storage key helpers and namespace clearing.\n- storageKeys.{settings,stats,daily(date)}\n- clearNamespace(namespace?) and clearAllSudoku()\n- Tests: __tests__/services/storage.keys.test.ts\n\nVerification: local CI (lint, typecheck, tests, build) green.\n\nCloses #169