### PR TITLE
feat(sync): baseline Supabase push/list for saved puzzles (#53)

### DIFF
--- a/__tests__/services/sync.test.ts
+++ b/__tests__/services/sync.test.ts
@@ -1,0 +1,76 @@
+import { jest } from '@jest/globals';
+
+jest.mock('@supabase/supabase-js', () => {
+  const rows: {
+    id: string;
+    user_id: string;
+    puzzle: string;
+    solution: string;
+    difficulty: string;
+    created_at: string;
+  }[] = [];
+  let signedIn = true;
+  const auth = {
+    getUser: jest.fn(async () =>
+      signedIn
+        ? { data: { user: { id: 'u_1' } }, error: null }
+        : { data: { user: null }, error: null },
+    ),
+  };
+  const from = jest.fn((table: string) => {
+    return {
+      insert: (payload: {
+        user_id: string;
+        puzzle: string;
+        solution: string;
+        difficulty: string;
+      }) => ({
+        select: () => ({
+          single: async () => {
+            if (table !== 'saved_puzzles') return { data: null, error: null };
+            const id = `id_${rows.length + 1}`;
+            rows.push({
+              id,
+              user_id: payload.user_id,
+              puzzle: payload.puzzle,
+              solution: payload.solution,
+              difficulty: payload.difficulty,
+              created_at: new Date().toISOString(),
+            });
+            return { data: { id }, error: null };
+          },
+        }),
+      }),
+      select: () => ({
+        eq: (
+          col: 'user_id' | 'id' | 'puzzle' | 'solution' | 'difficulty' | 'created_at',
+          val: string,
+        ) => ({
+          order: () => {
+            const filtered =
+              table === 'saved_puzzles' ? rows.filter((r) => String(r[col]) === val) : [];
+            return Promise.resolve({ data: filtered, error: null });
+          },
+        }),
+      }),
+    };
+  });
+  const createClient = jest.fn(() => ({ auth, from }));
+  return { createClient };
+});
+
+describe('sync service (#53)', () => {
+  it('pushes and lists saved puzzles for the signed-in user', async () => {
+    process.env['EXPO_PUBLIC_SUPABASE_URL'] = 'https://example.supabase.co';
+    process.env['EXPO_PUBLIC_SUPABASE_ANON_KEY'] = 'anon';
+    process.env['NODE_ENV'] = 'test';
+    jest.resetModules();
+    const { pushSavedPuzzle, listSavedPuzzles } = require('../../app/services/sync');
+
+    const push = await pushSavedPuzzle({ puzzle: 'p', solution: 's', difficulty: 'easy' });
+    expect(push.ok).toBe(true);
+
+    const list = await listSavedPuzzles();
+    expect(list.ok).toBe(true);
+  });
+});

--- a/__tests__/services/sync.test.ts
+++ b/__tests__/services/sync.test.ts
@@ -63,7 +63,6 @@ describe('sync service (#53)', () => {
   it('pushes and lists saved puzzles for the signed-in user', async () => {
     process.env['EXPO_PUBLIC_SUPABASE_URL'] = 'https://example.supabase.co';
     process.env['EXPO_PUBLIC_SUPABASE_ANON_KEY'] = 'anon';
-    process.env['NODE_ENV'] = 'test';
     jest.resetModules();
     const { pushSavedPuzzle, listSavedPuzzles } = require('../../app/services/sync');
 

--- a/app/services/sync.ts
+++ b/app/services/sync.ts
@@ -1,0 +1,50 @@
+import { supabase } from './supabase';
+
+export type SavedPuzzleInsert = {
+  puzzle: string;
+  solution: string;
+  difficulty: string;
+};
+
+export type SavedPuzzleRecord = SavedPuzzleInsert & {
+  id: string;
+  user_id: string;
+  created_at: string;
+};
+
+export async function pushSavedPuzzle(
+  data: SavedPuzzleInsert,
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+  if (!supabase) return { ok: false, error: 'Sync disabled: missing Supabase env' };
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr) return { ok: false, error: userErr.message };
+  const userId = userData?.user?.id;
+  if (!userId) return { ok: false, error: 'Not signed in' };
+
+  const payload = { ...data, user_id: userId } as const;
+  const { data: inserted, error } = await supabase
+    .from('saved_puzzles')
+    .insert(payload)
+    .select('id')
+    .single();
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, id: inserted!.id as string };
+}
+
+export async function listSavedPuzzles(): Promise<
+  { ok: true; items: SavedPuzzleRecord[] } | { ok: false; error: string }
+> {
+  if (!supabase) return { ok: false, error: 'Sync disabled: missing Supabase env' };
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr) return { ok: false, error: userErr.message };
+  const userId = userData?.user?.id;
+  if (!userId) return { ok: false, error: 'Not signed in' };
+
+  const { data, error } = await supabase
+    .from('saved_puzzles')
+    .select('id, user_id, puzzle, solution, difficulty, created_at')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, items: (data ?? []) as SavedPuzzleRecord[] };
+}


### PR DESCRIPTION
Adds minimal sync service using Supabase with RLS-friendly access.\n- Service: pp/services/sync.ts (pushSavedPuzzle, listSavedPuzzles)\n- Tests: __tests__/services/sync.test.ts (mocked supabase client)\n\nVerification: local CI (lint, typecheck, tests, build) green.\n\nCloses #53