### PR TITLE
feat(settings): add Settings screen wired to persistence with tests (#61)

### DIFF
--- a/__tests__/components/Settings.screen.test.tsx
+++ b/__tests__/components/Settings.screen.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { beforeEach } from '@jest/globals';
+import { fireEvent, render, waitFor, screen } from '@testing-library/react-native';
+import SettingsScreen from '../../app/settings.screen';
+import { __TEST_ONLY__clearProgress, loadProgress } from '../../app/services/storage';
+import { settingsKey } from '../../app/services/settings';
+import type { SettingsData } from '../../app/services/settings';
+
+describe('SettingsScreen (#61)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress(settingsKey());
+  });
+
+  it('toggles auto advance and persists', async () => {
+    render(<SettingsScreen />);
+    const toggle = await waitFor(() => screen.getByLabelText('Auto advance input'));
+    // default is true per defaults
+    fireEvent(toggle, 'valueChange', false);
+    await waitFor(async () => {
+      const saved = await loadProgress<SettingsData>(settingsKey());
+      expect(saved && saved.values.autoAdvance).toBe(false);
+    });
+  });
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,11 +2,12 @@ import React, { useContext, useState } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { ThemeContext } from './_layout';
 import ClassicScreen from './classic';
+import SettingsScreen from './settings.screen';
 import DailyScreen from './daily.screen';
 
 export default function IndexScreen() {
   const theme = useContext(ThemeContext);
-  const [screen, setScreen] = useState<'home' | 'classic' | 'daily'>('home');
+  const [screen, setScreen] = useState<'home' | 'classic' | 'daily' | 'settings'>('home');
 
   if (screen === 'classic') {
     return (
@@ -46,6 +47,25 @@ export default function IndexScreen() {
     );
   }
 
+  if (screen === 'settings') {
+    return (
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 12, alignItems: 'flex-start' }}>
+          <Pressable
+            onPress={() => setScreen('home')}
+            accessibilityRole="button"
+            accessibilityLabel="Return Home"
+            hitSlop={10}
+            style={{ paddingHorizontal: 12, paddingVertical: 6 }}
+          >
+            <Text style={{ color: theme.foreground, fontSize: 16 }}>{'← Home'}</Text>
+          </Pressable>
+        </View>
+        <SettingsScreen />
+      </View>
+    );
+  }
+
   return (
     <View
       style={{
@@ -78,6 +98,16 @@ export default function IndexScreen() {
       >
         <Text style={{ fontSize: 18, marginTop: 12, color: theme.isDark ? '#93c5fd' : '#2563eb' }}>
           Play Daily
+        </Text>
+      </Pressable>
+
+      <Pressable
+        onPress={() => setScreen('settings')}
+        accessibilityRole="button"
+        accessibilityLabel="Go to Settings"
+      >
+        <Text style={{ fontSize: 18, marginTop: 12, color: theme.isDark ? '#93c5fd' : '#2563eb' }}>
+          Settings
         </Text>
       </Pressable>
     </View>

--- a/app/settings.screen.tsx
+++ b/app/settings.screen.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState, useContext, useCallback } from 'react';
+import { View, Text, Switch } from 'react-native';
+import { ThemeContext } from './_layout';
+import { loadSettings, updateSettings, type SettingsData } from './services/settings';
+
+export default function SettingsScreen() {
+  const theme = useContext(ThemeContext);
+  const [settings, setSettings] = useState<SettingsData | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const s = await loadSettings();
+      if (mounted) setSettings(s);
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const onToggle = useCallback(
+    async (key: 'autoAdvance' | 'haptics' | 'errorHighlighting', value: boolean) => {
+      const next = await updateSettings(key, value);
+      setSettings(next);
+    },
+    [],
+  );
+
+  if (!settings) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text style={{ color: theme.foreground, opacity: 0.7 }}>Loading…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, paddingHorizontal: 20, paddingTop: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: '700', marginBottom: 16, color: theme.foreground }}>
+        Settings
+      </Text>
+
+      <View style={{ paddingVertical: 8, flexDirection: 'row', justifyContent: 'space-between' }}>
+        <Text
+          style={{ fontSize: 16, color: theme.foreground }}
+          accessibilityLabel="Auto advance input label"
+        >
+          Auto advance input
+        </Text>
+        <Switch
+          accessibilityLabel="Auto advance input"
+          value={settings.values.autoAdvance}
+          onValueChange={(v) => onToggle('autoAdvance', v)}
+        />
+      </View>
+
+      <View style={{ paddingVertical: 8, flexDirection: 'row', justifyContent: 'space-between' }}>
+        <Text style={{ fontSize: 16, color: theme.foreground }} accessibilityLabel="Haptics label">
+          Haptics
+        </Text>
+        <Switch
+          accessibilityLabel="Haptics"
+          value={settings.values.haptics}
+          onValueChange={(v) => onToggle('haptics', v)}
+        />
+      </View>
+
+      <View style={{ paddingVertical: 8, flexDirection: 'row', justifyContent: 'space-between' }}>
+        <Text
+          style={{ fontSize: 16, color: theme.foreground }}
+          accessibilityLabel="Error highlighting label"
+        >
+          Error highlighting
+        </Text>
+        <Switch
+          accessibilityLabel="Error highlighting"
+          value={settings.values.errorHighlighting}
+          onValueChange={(v) => onToggle('errorHighlighting', v)}
+        />
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
Adds a Settings screen wired to \pp/services/settings.ts\ and integrates basic toggles (auto advance, haptics, error highlighting).\n- Screen: \pp/settings.screen.tsx\\n- Nav: hooks into \pp/index.tsx\\n- Tests: \__tests__/components/Settings.screen.test.tsx\\n\nVerification: npm run ci (lint, typecheck, tests, build) green locally.\n\nCloses #61