### PR TITLE
feat(storage): storage health audit utils and settings conflict tests (#52)

### DIFF
--- a/__tests__/services/settings.conflicts.test.ts
+++ b/__tests__/services/settings.conflicts.test.ts
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+
+jest.mock('@supabase/supabase-js', () => {
+  const createClient = jest.fn(() => ({
+    auth: { getUser: jest.fn(async () => ({ data: { user: { id: 'u_1' } }, error: null })) },
+  }));
+  return { createClient };
+});
+
+import { mergeSettingsByTimestamps } from '../../app/services/sync';
+
+describe('settings conflict detection (#52)', () => {
+  it('prefers newer per-field timestamps', () => {
+    const base = {
+      settingsVersion: 1 as const,
+      values: {
+        errorHighlighting: true,
+        autoCandidates: 'default' as const,
+        autoAdvance: false,
+        haptics: true,
+        theme: 'system' as const,
+        accentColor: '#22c55e',
+        gridSize: 1,
+        inputSize: 1,
+        notesSize: 1,
+        calendarWeekStartsOn: 'mon' as const,
+        calendarFilter: 'all' as const,
+      },
+      timestamps: {},
+      lastSyncAttempt: 0,
+    };
+
+    const local = {
+      ...base,
+      values: { ...base.values, autoAdvance: false },
+      timestamps: { autoAdvance: 1000, updatedAt: 1000 },
+    };
+    const remote = {
+      ...base,
+      values: { ...base.values, autoAdvance: true },
+      timestamps: { autoAdvance: 2000, updatedAt: 2000 },
+    };
+
+    const merged = mergeSettingsByTimestamps(local, remote);
+    expect(merged.values.autoAdvance).toBe(true);
+    expect(merged.timestamps.autoAdvance).toBe(2000);
+    expect(merged.timestamps.updatedAt).toBeGreaterThanOrEqual(2000);
+  });
+});

--- a/__tests__/services/storage.health.test.ts
+++ b/__tests__/services/storage.health.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach } from '@jest/globals';
+import {
+  __TEST_ONLY__clearProgress,
+  saveProgress,
+  listSudokuKeys,
+  auditSudokuStorage,
+  storageKeys,
+} from '../../app/services/storage';
+
+describe('storage health & conflicts (#52)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress();
+  });
+
+  it('lists sudoku-* keys and audits JSON validity', async () => {
+    await saveProgress(storageKeys.settings(), { ok: true });
+    await saveProgress(storageKeys.stats(), { played: 1 });
+    const keys = listSudokuKeys();
+    expect(keys).toEqual(expect.arrayContaining([storageKeys.settings(), storageKeys.stats()]));
+
+    const audit = await auditSudokuStorage();
+    const settingsRow = audit.find((r) => r.key === storageKeys.settings());
+    expect(settingsRow?.validJson).toBe(true);
+  });
+});

--- a/app/services/storage.ts
+++ b/app/services/storage.ts
@@ -105,3 +105,97 @@ export function __TEST_ONLY__clearProgress(key?: string): void {
     }
   }
 }
+
+// --------------------------
+// Storage health/audit utils
+// --------------------------
+
+export type StorageAuditEntry = {
+  key: string;
+  validJson: boolean;
+  sizeBytes: number;
+  store: 'memory' | 'localStorage';
+};
+
+export function listSudokuKeys(namespace?: string): string[] {
+  const keys = new Set<string>();
+  // memory
+  for (const key of Array.from(memoryStore.keys())) {
+    if (keyMatchesNamespace(key, namespace)) keys.add(key);
+  }
+  // localStorage
+  if (typeof window !== 'undefined' && 'localStorage' in window && window.localStorage) {
+    try {
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const k = window.localStorage.key(i);
+        if (k && keyMatchesNamespace(k, namespace)) keys.add(k);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  return Array.from(keys).sort();
+}
+
+export async function auditSudokuStorage(namespace?: string): Promise<StorageAuditEntry[]> {
+  const results: StorageAuditEntry[] = [];
+
+  function getByteLength(raw: string): number {
+    try {
+      const TE = (
+        globalThis as unknown as { TextEncoder?: new () => { encode: (s: string) => Uint8Array } }
+      ).TextEncoder;
+      if (TE) return new TE().encode(raw).length;
+    } catch {
+      // ignore
+    }
+    const G = globalThis as unknown as {
+      Buffer?: { byteLength: (s: string, enc?: string) => number };
+    };
+    try {
+      if (G.Buffer && typeof G.Buffer.byteLength === 'function') {
+        return G.Buffer.byteLength(raw, 'utf8');
+      }
+    } catch {
+      // ignore
+    }
+    return raw.length;
+  }
+
+  // memory
+  for (const key of Array.from(memoryStore.keys())) {
+    if (!keyMatchesNamespace(key, namespace)) continue;
+    const raw = memoryStore.get(key) ?? '';
+    const sizeBytes = getByteLength(raw);
+    let validJson = true;
+    try {
+      JSON.parse(raw);
+    } catch {
+      validJson = false;
+    }
+    results.push({ key, validJson, sizeBytes, store: 'memory' });
+  }
+
+  // localStorage
+  if (typeof window !== 'undefined' && 'localStorage' in window && window.localStorage) {
+    try {
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (!key || !keyMatchesNamespace(key, namespace)) continue;
+        const raw = window.localStorage.getItem(key) ?? '';
+        const sizeBytes = getByteLength(raw);
+        let validJson = true;
+        try {
+          JSON.parse(raw);
+        } catch {
+          validJson = false;
+        }
+        results.push({ key, validJson, sizeBytes, store: 'localStorage' });
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return results.sort((a, b) => a.key.localeCompare(b.key));
+}


### PR DESCRIPTION
Adds storage health auditing utilities and tests.\n- listSudokuKeys, auditSudokuStorage in \pp/services/storage.ts\\n- Tests: \__tests__/services/storage.health.test.ts\, \__tests__/services/settings.conflicts.test.ts\\n\nVerification: npm run ci (lint, typecheck, tests, build) green locally.\n\nCloses #52