### PR TITLE
test(daily): fixed lives by difficulty (hard→4) (#50)

### DIFF
--- a/__tests__/app/daily.lives.fixed.test.tsx
+++ b/__tests__/app/daily.lives.fixed.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import DailyScreen from '../../app/daily.screen';
+import { __TEST_ONLY__clearProgress } from '../../app/services/storage';
+import { beforeEach } from '@jest/globals';
+
+// Mock the daily module to force a deterministic difficulty → lives mapping
+// We pick 'hard' → livesForDifficulty returns 4 for Daily
+jest.mock('../../app/game/daily', () => {
+  return {
+    createDailySeed: () => ({ utcDate: '20250113', patternId: 'A', difficulty: 'hard' }),
+    formatDailySeed: () => '20250113-A-hard',
+    generateDailyPuzzle: () => ({ givens: [] }),
+    __esModule: true,
+    default: jest.fn(),
+  };
+});
+
+describe('DailyScreen fixed lives by difficulty (#50)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress();
+  });
+
+  it('initializes lives from difficulty (hard → 4 lives)', () => {
+    render(<DailyScreen />);
+    const node = screen.getByLabelText(/\d+ lives remaining/);
+    const label = String(node?.props?.accessibilityLabel ?? ''); // RN testing lib stores label here
+    const match = label.match(/(\d+) lives remaining/);
+    const lives = match ? Number(match[1]) : NaN;
+    expect(lives).toBe(4);
+  });
+});


### PR DESCRIPTION
Adds deterministic test confirming Daily initializes lives from difficulty mapping.\n- Mocks seed to hard → expects 4 lives\n- CI/typecheck/lint/build green locally