### PR TITLE
feat(stats): UTC daily streak computation + tests (#49)

### DIFF
--- a/__tests__/app/daily.lives.fixed.test.tsx
+++ b/__tests__/app/daily.lives.fixed.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import DailyScreen from '../../app/daily.screen';
+import { __TEST_ONLY__clearProgress } from '../../app/services/storage';
+import { beforeEach } from '@jest/globals';
+
+// Mock the daily module to force a deterministic difficulty → lives mapping
+// We pick 'hard' → livesForDifficulty returns 4 for Daily
+jest.mock('../../app/game/daily', () => {
+  return {
+    createDailySeed: () => ({ utcDate: '20250113', patternId: 'A', difficulty: 'hard' }),
+    formatDailySeed: () => '20250113-A-hard',
+    generateDailyPuzzle: () => ({ givens: [] }),
+    __esModule: true,
+    default: jest.fn(),
+  };
+});
+
+describe('DailyScreen fixed lives by difficulty (#50)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress();
+  });
+
+  it('initializes lives from difficulty (hard → 4 lives)', () => {
+    render(<DailyScreen />);
+    const node = screen.getByLabelText(/\d+ lives remaining/);
+    const label = String(node?.props?.accessibilityLabel ?? ''); // RN testing lib stores label here
+    const match = label.match(/(\d+) lives remaining/);
+    const lives = match ? Number(match[1]) : NaN;
+    expect(lives).toBe(4);
+  });
+});

--- a/__tests__/services/stats.streaks.test.ts
+++ b/__tests__/services/stats.streaks.test.ts
@@ -1,0 +1,39 @@
+import { computeStreaks, type DailyResult } from '../../app/services/stats';
+
+describe('UTC daily streaks (#49)', () => {
+  it('computes current and best streaks over recentDailyResults', () => {
+    const results: DailyResult[] = [
+      // Newest first or mixed order is fine; computeStreaks sorts internally
+      { date: '20250106', result: 'win', seconds: 120, usedHints: false },
+      { date: '20250105', result: 'win', seconds: 100, usedHints: false },
+      { date: '20250104', result: 'loss', seconds: 200, usedHints: false },
+      { date: '20250103', result: 'win', seconds: 130, usedHints: true },
+      { date: '20250102', result: 'win', seconds: 130, usedHints: false },
+      { date: '20250101', result: 'win', seconds: 130, usedHints: false },
+    ];
+    // Winning days: 20250106, 20250105 (gap at 04), then 03,02,01 ⇒ best=3; current streak at head=2
+    const streaks = computeStreaks(results);
+    expect(streaks.best).toBe(3);
+    expect(streaks.current).toBe(2);
+  });
+
+  it('counts a day as win if any result that day is a win', () => {
+    const results: DailyResult[] = [
+      { date: '20250110', result: 'loss', seconds: 50, usedHints: false },
+      { date: '20250110', result: 'win', seconds: 40, usedHints: false },
+      { date: '20250109', result: 'win', seconds: 40, usedHints: false },
+    ];
+    const streaks = computeStreaks(results);
+    expect(streaks.current).toBe(2);
+    expect(streaks.best).toBe(2);
+  });
+
+  it('returns zeros when no wins present', () => {
+    const results: DailyResult[] = [
+      { date: '20250101', result: 'loss', seconds: 10, usedHints: false },
+      { date: '20250103', result: 'loss', seconds: 10, usedHints: false },
+    ];
+    const s = computeStreaks(results);
+    expect(s).toEqual({ current: 0, best: 0 });
+  });
+});

--- a/app/services/stats.ts
+++ b/app/services/stats.ts
@@ -129,3 +129,79 @@ export async function recordDailyResult(
     dateUTC,
   });
 }
+
+export type Streaks = { current: number; best: number };
+
+function parseUTCDateToDayIndex(yyyyMMdd: string): number | null {
+  if (!/^\d{8}$/.test(yyyyMMdd)) return null;
+  const y = Number(yyyyMMdd.slice(0, 4));
+  const m = Number(yyyyMMdd.slice(4, 6)) - 1;
+  const d = Number(yyyyMMdd.slice(6, 8));
+  const ms = Date.UTC(y, m, d);
+  return Math.floor(ms / 86400000);
+}
+
+/**
+ * Compute current and best daily win streaks (by UTC date) from a list of results.
+ * - Multiple entries per day are collapsed: a day counts as a win if any result is a win.
+ * - Current streak counts consecutive winning days starting from the most recent winning day
+ *   and stops at the first gap.
+ */
+export function computeStreaks(results: DailyResult[]): Streaks {
+  if (!Array.isArray(results) || results.length === 0) return { current: 0, best: 0 };
+
+  // Collapse to per-day win flags
+  const dayToWin = new Map<number, boolean>();
+  for (const r of results) {
+    const day = parseUTCDateToDayIndex(r.date);
+    if (day == null) continue;
+    if (r.result === 'win') {
+      dayToWin.set(day, true);
+    } else if (!dayToWin.has(day)) {
+      dayToWin.set(day, false);
+    }
+  }
+
+  // Keep only winning days; gaps implicitly break streaks
+  const winDays = Array.from(dayToWin.entries())
+    .filter(([, isWin]) => isWin)
+    .map(([day]) => day)
+    .sort((a, b) => b - a); // newest first
+
+  if (winDays.length === 0) return { current: 0, best: 0 };
+
+  let best = 0;
+  let current = 0;
+  let temp = 0;
+  let prev: number | null = null;
+  let atHead = true;
+
+  for (const day of winDays) {
+    if (prev == null) {
+      temp = 1;
+      current = 1; // first winning day always sets current streak to at least 1
+    } else if (day === prev - 1) {
+      temp += 1;
+      if (atHead) current = temp;
+    } else {
+      // gap encountered; end of current streak window
+      atHead = false;
+      temp = 1;
+    }
+    if (temp > best) best = temp;
+    prev = day;
+  }
+
+  return { current, best };
+}
+
+export async function getStreaks(): Promise<Streaks> {
+  const stats = (await loadStats()) ?? {
+    schemaVersion: 2 as const,
+    totals: { played: 0, wins: 0, losses: 0 },
+    bestTimeByDifficulty: {},
+    recentDailyResults: [],
+    lastCalculated: 0,
+  };
+  return computeStreaks(stats.recentDailyResults);
+}


### PR DESCRIPTION
- Adds computeStreaks() and getStreaks() for UTC-based streaks\n- Tests for current/best streaks and day-collapsing\n- All local checks green