### PR TITLE
feat(daily): calendar service + UI and tests (#39)

### DIFF
--- a/__tests__/app/daily.calendar.screen.test.tsx
+++ b/__tests__/app/daily.calendar.screen.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import DailyCalendarScreen from '../../app/daily.calendar.screen';
+
+jest.mock('../../app/services/dailyCalendar', () => {
+  return {
+    buildMonthMatrix: () => [
+      [
+        { utcDate: '20250101', isInMonth: true, isToday: false, isFuture: false, completed: false },
+        { utcDate: '20250102', isInMonth: true, isToday: false, isFuture: false, completed: true },
+        { utcDate: '20250103', isInMonth: true, isToday: true, isFuture: false, completed: false },
+        { utcDate: '20250104', isInMonth: true, isToday: false, isFuture: true, completed: false },
+      ],
+    ],
+    __esModule: true,
+  };
+});
+
+describe('DailyCalendarScreen (#39)', () => {
+  it('renders days with completion and lock states', () => {
+    render(<DailyCalendarScreen />);
+    expect(screen.getByLabelText('20250101')).toBeTruthy();
+    expect(screen.getByLabelText('20250102 completed')).toBeTruthy();
+    expect(screen.getByLabelText('20250103')).toBeTruthy();
+    expect(screen.getByLabelText('20250104 locked')).toBeTruthy();
+  });
+});

--- a/__tests__/app/daily.lives.fixed.test.tsx
+++ b/__tests__/app/daily.lives.fixed.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import DailyScreen from '../../app/daily.screen';
+import { __TEST_ONLY__clearProgress } from '../../app/services/storage';
+import { beforeEach } from '@jest/globals';
+
+// Mock the daily module to force a deterministic difficulty → lives mapping
+// We pick 'hard' → livesForDifficulty returns 4 for Daily
+jest.mock('../../app/game/daily', () => {
+  return {
+    createDailySeed: () => ({ utcDate: '20250113', patternId: 'A', difficulty: 'hard' }),
+    formatDailySeed: () => '20250113-A-hard',
+    generateDailyPuzzle: () => ({ givens: [] }),
+    __esModule: true,
+    default: jest.fn(),
+  };
+});
+
+describe('DailyScreen fixed lives by difficulty (#50)', () => {
+  beforeEach(() => {
+    __TEST_ONLY__clearProgress();
+  });
+
+  it('initializes lives from difficulty (hard → 4 lives)', () => {
+    render(<DailyScreen />);
+    const node = screen.getByLabelText(/\d+ lives remaining/);
+    const label = String(node?.props?.accessibilityLabel ?? ''); // RN testing lib stores label here
+    const match = label.match(/(\d+) lives remaining/);
+    const lives = match ? Number(match[1]) : NaN;
+    expect(lives).toBe(4);
+  });
+});

--- a/__tests__/services/dailyCalendar.test.ts
+++ b/__tests__/services/dailyCalendar.test.ts
@@ -1,0 +1,40 @@
+import { buildMonthMatrix, getTodayUTCDateString } from '../../app/services/dailyCalendar';
+import type { StatsData } from '../../app/services/stats';
+
+describe('daily calendar service (#39)', () => {
+  it('marks future days locked and completed days based on stats', () => {
+    const today = new Date(Date.UTC(2025, 0, 15)); // Jan 15, 2025 UTC
+    const completedUTC = ['20250102', '20250110', '20250115'];
+    const stats: StatsData = {
+      schemaVersion: 2,
+      totals: { played: 0, wins: 0, losses: 0 },
+      bestTimeByDifficulty: {},
+      recentDailyResults: completedUTC.map((d) => ({
+        date: d,
+        result: 'win',
+        seconds: 100,
+        usedHints: false,
+      })),
+      lastCalculated: today.getTime(),
+    };
+
+    const grid = buildMonthMatrix(2025, 0, stats, today);
+    const flat = grid.flat();
+    const find = (d: string) => flat.find((x) => x.utcDate === d)!;
+    // Completed flags
+    expect(find('20250102').completed).toBe(true);
+    expect(find('20250110').completed).toBe(true);
+    expect(find('20250115').completed).toBe(true);
+    // Future lock
+    expect(find('20250116').isFuture).toBe(true);
+    // Today marker
+    expect(find('20250115').isToday).toBe(true);
+    // In-month flags
+    expect(find('20250101').isInMonth).toBe(true);
+  });
+
+  it('returns correct today UTC string helper', () => {
+    const d = new Date(Date.UTC(2025, 5, 3));
+    expect(getTodayUTCDateString(d)).toBe('20250603');
+  });
+});

--- a/__tests__/services/stats.streaks.test.ts
+++ b/__tests__/services/stats.streaks.test.ts
@@ -1,0 +1,39 @@
+import { computeStreaks, type DailyResult } from '../../app/services/stats';
+
+describe('UTC daily streaks (#49)', () => {
+  it('computes current and best streaks over recentDailyResults', () => {
+    const results: DailyResult[] = [
+      // Newest first or mixed order is fine; computeStreaks sorts internally
+      { date: '20250106', result: 'win', seconds: 120, usedHints: false },
+      { date: '20250105', result: 'win', seconds: 100, usedHints: false },
+      { date: '20250104', result: 'loss', seconds: 200, usedHints: false },
+      { date: '20250103', result: 'win', seconds: 130, usedHints: true },
+      { date: '20250102', result: 'win', seconds: 130, usedHints: false },
+      { date: '20250101', result: 'win', seconds: 130, usedHints: false },
+    ];
+    // Winning days: 20250106, 20250105 (gap at 04), then 03,02,01 ⇒ best=3; current streak at head=2
+    const streaks = computeStreaks(results);
+    expect(streaks.best).toBe(3);
+    expect(streaks.current).toBe(2);
+  });
+
+  it('counts a day as win if any result that day is a win', () => {
+    const results: DailyResult[] = [
+      { date: '20250110', result: 'loss', seconds: 50, usedHints: false },
+      { date: '20250110', result: 'win', seconds: 40, usedHints: false },
+      { date: '20250109', result: 'win', seconds: 40, usedHints: false },
+    ];
+    const streaks = computeStreaks(results);
+    expect(streaks.current).toBe(2);
+    expect(streaks.best).toBe(2);
+  });
+
+  it('returns zeros when no wins present', () => {
+    const results: DailyResult[] = [
+      { date: '20250101', result: 'loss', seconds: 10, usedHints: false },
+      { date: '20250103', result: 'loss', seconds: 10, usedHints: false },
+    ];
+    const s = computeStreaks(results);
+    expect(s).toEqual({ current: 0, best: 0 });
+  });
+});

--- a/app/daily.calendar.screen.tsx
+++ b/app/daily.calendar.screen.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { buildMonthMatrix } from './services/dailyCalendar';
+import { ThemeContext } from './_layout';
+
+export default function DailyCalendarScreen() {
+  const theme = React.useContext(ThemeContext);
+  const now = useMemo(() => new Date(), []);
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const grid = useMemo(() => buildMonthMatrix(year, month, null, now), [year, month, now]);
+
+  return (
+    <View style={{ flex: 1, paddingHorizontal: 20, paddingTop: 12 }}>
+      <Text style={{ fontSize: 22, fontWeight: '700', marginBottom: 12, color: theme.foreground }}>
+        Daily Calendar (UTC)
+      </Text>
+      <View style={{ gap: 6 }}>
+        {grid.map((week, wi) => (
+          <View key={`w-${wi}`} style={{ flexDirection: 'row', gap: 6 }}>
+            {week.map((day) => (
+              <Pressable
+                key={day.utcDate}
+                accessibilityRole="button"
+                accessibilityLabel={`${day.utcDate}${day.completed ? ' completed' : ''}${day.isFuture ? ' locked' : ''}`}
+                accessibilityHint={day.isFuture ? 'Future dates are locked' : undefined}
+                disabled={day.isFuture}
+                style={{
+                  width: 40,
+                  height: 40,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: 6,
+                  backgroundColor: day.isToday
+                    ? theme.isDark
+                      ? '#1f2937'
+                      : '#dbeafe'
+                    : day.completed
+                      ? theme.isDark
+                        ? '#065f46'
+                        : '#bbf7d0'
+                      : theme.isDark
+                        ? '#111827'
+                        : '#f3f4f6',
+                  opacity: day.isInMonth ? 1 : 0.5,
+                }}
+              >
+                <Text style={{ color: theme.isDark ? '#e5e7eb' : '#111827', fontSize: 12 }}>
+                  {day.utcDate.slice(6, 8)}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,10 +4,13 @@ import { ThemeContext } from './_layout';
 import ClassicScreen from './classic';
 import SettingsScreen from './settings.screen';
 import DailyScreen from './daily.screen';
+import DailyCalendarScreen from './daily.calendar.screen';
 
 export default function IndexScreen() {
   const theme = useContext(ThemeContext);
-  const [screen, setScreen] = useState<'home' | 'classic' | 'daily' | 'settings'>('home');
+  const [screen, setScreen] = useState<'home' | 'classic' | 'daily' | 'calendar' | 'settings'>(
+    'home',
+  );
 
   if (screen === 'classic') {
     return (
@@ -43,6 +46,25 @@ export default function IndexScreen() {
           </Pressable>
         </View>
         <DailyScreen />
+      </View>
+    );
+  }
+
+  if (screen === 'calendar') {
+    return (
+      <View style={{ flex: 1 }}>
+        <View style={{ paddingHorizontal: 20, paddingTop: 12, alignItems: 'flex-start' }}>
+          <Pressable
+            onPress={() => setScreen('home')}
+            accessibilityRole="button"
+            accessibilityLabel="Return Home"
+            hitSlop={10}
+            style={{ paddingHorizontal: 12, paddingVertical: 6 }}
+          >
+            <Text style={{ color: theme.foreground, fontSize: 16 }}>{'← Home'}</Text>
+          </Pressable>
+        </View>
+        <DailyCalendarScreen />
       </View>
     );
   }
@@ -98,6 +120,16 @@ export default function IndexScreen() {
       >
         <Text style={{ fontSize: 18, marginTop: 12, color: theme.isDark ? '#93c5fd' : '#2563eb' }}>
           Play Daily
+        </Text>
+      </Pressable>
+
+      <Pressable
+        onPress={() => setScreen('calendar')}
+        accessibilityRole="button"
+        accessibilityLabel="Go to Daily Calendar"
+      >
+        <Text style={{ fontSize: 18, marginTop: 12, color: theme.isDark ? '#93c5fd' : '#2563eb' }}>
+          Daily Calendar
         </Text>
       </Pressable>
 

--- a/app/services/dailyCalendar.ts
+++ b/app/services/dailyCalendar.ts
@@ -1,0 +1,89 @@
+import type { StatsData, DailyResult } from './stats';
+
+export type CalendarDay = {
+  utcDate: string; // YYYYMMDD
+  isInMonth: boolean;
+  isToday: boolean;
+  isFuture: boolean;
+  completed: boolean; // any win recorded for that UTC date
+};
+
+function formatUTCDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}${m}${dd}`;
+}
+
+function dayIndex(d: Date): number {
+  return Math.floor(d.getTime() / 86400000);
+}
+
+function parseDayIndex(utc: string): number | null {
+  if (!/^\d{8}$/.test(utc)) return null;
+  const y = Number(utc.slice(0, 4));
+  const m = Number(utc.slice(4, 6)) - 1;
+  const dd = Number(utc.slice(6, 8));
+  return Math.floor(Date.UTC(y, m, dd) / 86400000);
+}
+
+export function getTodayUTCDateString(now: Date = new Date()): string {
+  return formatUTCDate(
+    new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())),
+  );
+}
+
+function buildCompletionSet(recent: DailyResult[]): Set<number> {
+  const set = new Set<number>();
+  for (const r of recent) {
+    if (r.result !== 'win') continue;
+    const idx = parseDayIndex(r.date);
+    if (idx != null) set.add(idx);
+  }
+  return set;
+}
+
+/**
+ * Build a 6x7 calendar matrix for the given UTC month.
+ * - Weeks start on Sunday (UTC).
+ * - Future days relative to `today` are marked isFuture=true.
+ * - Completion is derived from StatsData.recentDailyResults.
+ */
+export function buildMonthMatrix(
+  yearUTC: number,
+  monthIndexUTC: number, // 0-based
+  stats: StatsData | null,
+  today: Date = new Date(),
+): CalendarDay[][] {
+  const firstOfMonth = new Date(Date.UTC(yearUTC, monthIndexUTC, 1));
+  const firstWeekday = firstOfMonth.getUTCDay(); // 0=Sun
+  const start = new Date(firstOfMonth.getTime() - firstWeekday * 86400000);
+  const todayIdx = dayIndex(
+    new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())),
+  );
+  const completeSet = buildCompletionSet(stats?.recentDailyResults ?? []);
+
+  const out: CalendarDay[][] = [];
+  let cursor = new Date(start);
+  for (let w = 0; w < 6; w++) {
+    const row: CalendarDay[] = [];
+    for (let d = 0; d < 7; d++) {
+      const idx = dayIndex(cursor);
+      const utc = formatUTCDate(cursor);
+      const isInMonth =
+        cursor.getUTCFullYear() === yearUTC && cursor.getUTCMonth() === monthIndexUTC;
+      const isToday = idx === todayIdx;
+      const isFuture = idx > todayIdx;
+      row.push({
+        utcDate: utc,
+        isInMonth,
+        isToday,
+        isFuture,
+        completed: completeSet.has(idx),
+      });
+      cursor = new Date(cursor.getTime() + 86400000);
+    }
+    out.push(row);
+  }
+  return out;
+}

--- a/app/services/stats.ts
+++ b/app/services/stats.ts
@@ -129,3 +129,79 @@ export async function recordDailyResult(
     dateUTC,
   });
 }
+
+export type Streaks = { current: number; best: number };
+
+function parseUTCDateToDayIndex(yyyyMMdd: string): number | null {
+  if (!/^\d{8}$/.test(yyyyMMdd)) return null;
+  const y = Number(yyyyMMdd.slice(0, 4));
+  const m = Number(yyyyMMdd.slice(4, 6)) - 1;
+  const d = Number(yyyyMMdd.slice(6, 8));
+  const ms = Date.UTC(y, m, d);
+  return Math.floor(ms / 86400000);
+}
+
+/**
+ * Compute current and best daily win streaks (by UTC date) from a list of results.
+ * - Multiple entries per day are collapsed: a day counts as a win if any result is a win.
+ * - Current streak counts consecutive winning days starting from the most recent winning day
+ *   and stops at the first gap.
+ */
+export function computeStreaks(results: DailyResult[]): Streaks {
+  if (!Array.isArray(results) || results.length === 0) return { current: 0, best: 0 };
+
+  // Collapse to per-day win flags
+  const dayToWin = new Map<number, boolean>();
+  for (const r of results) {
+    const day = parseUTCDateToDayIndex(r.date);
+    if (day == null) continue;
+    if (r.result === 'win') {
+      dayToWin.set(day, true);
+    } else if (!dayToWin.has(day)) {
+      dayToWin.set(day, false);
+    }
+  }
+
+  // Keep only winning days; gaps implicitly break streaks
+  const winDays = Array.from(dayToWin.entries())
+    .filter(([, isWin]) => isWin)
+    .map(([day]) => day)
+    .sort((a, b) => b - a); // newest first
+
+  if (winDays.length === 0) return { current: 0, best: 0 };
+
+  let best = 0;
+  let current = 0;
+  let temp = 0;
+  let prev: number | null = null;
+  let atHead = true;
+
+  for (const day of winDays) {
+    if (prev == null) {
+      temp = 1;
+      current = 1; // first winning day always sets current streak to at least 1
+    } else if (day === prev - 1) {
+      temp += 1;
+      if (atHead) current = temp;
+    } else {
+      // gap encountered; end of current streak window
+      atHead = false;
+      temp = 1;
+    }
+    if (temp > best) best = temp;
+    prev = day;
+  }
+
+  return { current, best };
+}
+
+export async function getStreaks(): Promise<Streaks> {
+  const stats = (await loadStats()) ?? {
+    schemaVersion: 2 as const,
+    totals: { played: 0, wins: 0, losses: 0 },
+    bestTimeByDifficulty: {},
+    recentDailyResults: [],
+    lastCalculated: 0,
+  };
+  return computeStreaks(stats.recentDailyResults);
+}


### PR DESCRIPTION
Adds UTC calendar grid with locked future and completion flags; new UI screen and tests; local checks green.