### PR TITLE
Add a11y smoke test and storage error-handling test

### DIFF
--- a/__tests__/app/settings.a11y.test.tsx
+++ b/__tests__/app/settings.a11y.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react-native';
+import SettingsScreen from '../../app/settings.screen';
+
+describe('SettingsScreen accessibility', () => {
+  it('exposes accessible switch for Auto advance input', async () => {
+    render(<SettingsScreen />);
+    const toggle = await waitFor(() => screen.getByLabelText('Auto advance input'));
+    expect(toggle).toBeTruthy();
+    expect(toggle.props?.accessibilityRole).toBe('switch');
+  });
+});
+
+

--- a/__tests__/app/storage.errors.test.tsx
+++ b/__tests__/app/storage.errors.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react-native';
+import ClassicScreen from '../../app/classic';
+
+describe('Storage error handling', () => {
+  it('gracefully handles corrupted storage on load', async () => {
+    const key = 'sudoku-progress';
+    // Corrupt localStorage entry
+    globalThis.localStorage?.setItem(key, '{ not: json');
+
+    render(<ClassicScreen />);
+    // App should still render and not crash; header title visible
+    expect(await screen.findByText('Ultimate Sudoku')).toBeTruthy();
+    // Timer still mounts despite storage parse failure
+    await waitFor(() => expect(screen.getByLabelText('Elapsed time')).toBeTruthy());
+  });
+});
+
+


### PR DESCRIPTION
Adds Settings screen a11y smoke (accessible switch) and Classic storage corruption resilience test.\n\nLinked Epic: #335\n