### PR TITLE
feat(a11y): core a11y for Board/Numpad (Issue #170)

### DIFF
--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -56,11 +56,20 @@ export default function Board({
                 onPress={() => onSelect(r, c)}
                 accessibilityRole="button"
                 accessibilityLabel={`Cell ${r + 1},${c + 1}`}
+                accessibilityState={{ selected: !!isSelected, disabled: false }}
                 accessibilityHint={`${
                   cell.value != null ? `Value ${cell.value}` : 'Empty'
                 }${cell.isGiven ? ', given' : ''}${cell.isError ? ', error' : ''}${
                   isHighlighted ? ', highlighted' : ''
                 }`}
+                accessibilityValue={{
+                  text:
+                    cell.value != null
+                      ? `Value ${cell.value}${cell.isGiven ? ', given' : ''}`
+                      : noteDigits.length > 0
+                        ? `Notes ${noteDigits.join('')}`
+                        : 'Empty',
+                }}
                 testID={`cell-${r + 1}-${c + 1}${isHighlighted ? '-highlight' : ''}`}
                 style={{
                   width: cellSize,

--- a/app/components/Numpad.tsx
+++ b/app/components/Numpad.tsx
@@ -37,6 +37,8 @@ export default function Numpad({
                 onLongPress={() => onToggleLock(d)}
                 accessibilityRole="button"
                 accessibilityLabel={`Digit ${d}${isLocked ? ' locked' : isHighlighted ? ' highlighted' : ''}`}
+                accessibilityState={{ selected: isLocked }}
+                accessibilityHint={isLocked ? 'Long press to unlock' : 'Long press to lock'}
                 style={{
                   width: size,
                   height: size,


### PR DESCRIPTION
Implements Issue #170\n\n- Board cells: accessibilityState selected/value, descriptive hints\n- Numpad: selected state + hints for lock\n\nParent Epic: #21