### PR TITLE
feat(a11y): screen reader and focus improvements (Issue #176)

### DIFF
--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -50,17 +50,30 @@ export default function Board({
             const noteDigits = Object.keys(cell.notes)
               .map((k) => Number(k))
               .sort((a, b) => a - b);
+            const candidateCount = noteDigits.length;
+            const hintParts: string[] = [];
+            hintParts.push(cell.value != null ? `Value ${cell.value}` : 'Empty');
+            if (cell.isGiven) hintParts.push('given');
+            if (cell.isError) hintParts.push('error');
+            if (isHighlighted) hintParts.push('highlighted');
+            if (candidateCount > 0 && cell.value == null)
+              hintParts.push(`${candidateCount} candidates`);
             return (
               <Pressable
                 key={c}
                 onPress={() => onSelect(r, c)}
                 accessibilityRole="button"
                 accessibilityLabel={`Cell ${r + 1},${c + 1}`}
-                accessibilityHint={`${
-                  cell.value != null ? `Value ${cell.value}` : 'Empty'
-                }${cell.isGiven ? ', given' : ''}${cell.isError ? ', error' : ''}${
-                  isHighlighted ? ', highlighted' : ''
-                }`}
+                accessibilityState={{ selected: !!isSelected }}
+                accessibilityHint={hintParts.join(', ')}
+                accessibilityValue={{
+                  text:
+                    cell.value != null
+                      ? `Value ${cell.value}${cell.isGiven ? ', given' : ''}`
+                      : candidateCount > 0
+                        ? `${candidateCount} candidate${candidateCount === 1 ? '' : 's'}`
+                        : 'Empty',
+                }}
                 testID={`cell-${r + 1}-${c + 1}${isHighlighted ? '-highlight' : ''}`}
                 style={{
                   width: cellSize,


### PR DESCRIPTION
Implements Issue #176\n\n- Board: candidate counts in hints/value, selected state\n- Improves SR announcements for empty vs noted cells\n\nParent Epic: #21