### PR TITLE
feat(a11y): visible focus ring and keyboard focus alignment (Issue #392)

### DIFF
--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -30,7 +30,7 @@ export default function Board({
             const borderColor = cell.isError
               ? '#ef4444'
               : isSelected
-                ? '#60a5fa'
+                ? '#2563eb'
                 : isHighlighted
                   ? '#93c5fd'
                   : theme.isDark
@@ -54,6 +54,7 @@ export default function Board({
               <Pressable
                 key={c}
                 onPress={() => onSelect(r, c)}
+                onFocus={() => onSelect(r, c)}
                 accessibilityRole="button"
                 accessibilityLabel={`Cell ${r + 1},${c + 1}`}
                 accessibilityState={{ selected: !!isSelected, disabled: false }}


### PR DESCRIPTION
Implements Issue #392\n\n- Stronger focus ring color when selected\n- onFocus now updates selection to mirror keyboard/SR focus\n\nParent Epic: #21