### PR TITLE
feat(engine): Ultimate levels recipes + generator path (Issue #400)

### DIFF
--- a/__tests__/game/levels.generator.test.ts
+++ b/__tests__/game/levels.generator.test.ts
@@ -1,0 +1,23 @@
+import { generatePuzzle } from '../../app/game/engine/generator';
+
+describe('Ultimate Levels generator', () => {
+  const seed = 'test-seed-1234';
+
+  it('generates Novice within clue window', () => {
+    const p = generatePuzzle({ seed, level: 'novice' });
+    expect(p.givens.length).toBeGreaterThanOrEqual(36);
+    expect(p.givens.length).toBeLessThanOrEqual(40);
+  });
+
+  it('generates Skilled within clue window', () => {
+    const p = generatePuzzle({ seed, level: 'skilled' });
+    expect(p.givens.length).toBeGreaterThanOrEqual(30);
+    expect(p.givens.length).toBeLessThanOrEqual(34);
+  });
+
+  it('generates Ultimate within clue window', () => {
+    const p = generatePuzzle({ seed, level: 'ultimate' });
+    expect(p.givens.length).toBeGreaterThanOrEqual(17);
+    expect(p.givens.length).toBeLessThanOrEqual(22);
+  });
+});

--- a/app/game/engine/generator.ts
+++ b/app/game/engine/generator.ts
@@ -1,4 +1,6 @@
 import type { Digit, Difficulty } from '../types';
+import type { UltimateLevel } from './levels';
+import { pickTargetCluesForLevel } from './levels';
 import { createRng, hashStringToSeed, shuffled } from './random';
 import { cloneGrid, countSolutions } from './solver';
 import { pickTargetClues, generateMask, symmetryModes } from './masks';
@@ -7,6 +9,7 @@ export type GenerateOptions = {
   seed: string;
   difficulty?: Difficulty; // if provided, aim to meet clue thresholds fast
   minClues?: number; // legacy/override when uniqueness mode used
+  level?: UltimateLevel; // new Ultimate levels API
 };
 
 export type GeneratedPuzzle = {
@@ -53,10 +56,34 @@ function generateSolvedGrid(seed: string): (Digit | null)[][] {
 }
 
 export function generatePuzzle(options: GenerateOptions): GeneratedPuzzle {
-  const { seed, difficulty, minClues } = options;
+  const { seed, difficulty, minClues, level } = options;
 
   // Always compute a solved grid quickly
   const solution = cloneGrid(generateSolvedGrid(seed));
+
+  if (level) {
+    // Ultimate levels path: target per-level clue window and symmetric masks
+    const target = pickTargetCluesForLevel(seed, level);
+    const modes = symmetryModes(seed);
+    let attempts = 0;
+    let mask: boolean[][] | null = null;
+    while (attempts < 4) {
+      const mode = modes.next().value;
+      mask = generateMask(seed, target, mode);
+      if (mask) break;
+      attempts++;
+    }
+
+    const givens: { row: number; col: number; value: Digit }[] = [];
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        if (mask![r]![c]) {
+          givens.push({ row: r, col: c, value: solution[r]![c]! });
+        }
+      }
+    }
+    return { givens, solution };
+  }
 
   if (difficulty) {
     // Fast path: honor clue thresholds without expensive uniqueness checks

--- a/app/game/engine/levels.ts
+++ b/app/game/engine/levels.ts
@@ -1,0 +1,75 @@
+import { createRng, hashStringToSeed } from './random';
+
+export type UltimateLevel = 'novice' | 'skilled' | 'advanced' | 'expert' | 'fiendish' | 'ultimate';
+
+export type LevelRecipe = {
+  minClues: number;
+  maxClues: number;
+  // Placeholder: list of technique identifiers to validate against in solver
+  allowedTechniques: string[];
+};
+
+export const LEVEL_RECIPES: Record<UltimateLevel, LevelRecipe> = {
+  novice: {
+    minClues: 36,
+    maxClues: 40,
+    allowedTechniques: ['nakedSingle', 'hiddenSingle'],
+  },
+  skilled: {
+    minClues: 30,
+    maxClues: 34,
+    allowedTechniques: [
+      'nakedSingle',
+      'hiddenSingle',
+      'lockedCandidates',
+      'nakedPair',
+      'hiddenPair',
+      'boxLine',
+    ],
+  },
+  advanced: {
+    minClues: 26,
+    maxClues: 30,
+    allowedTechniques: [
+      'nakedSingle',
+      'hiddenSingle',
+      'lockedCandidates',
+      'nakedPair',
+      'hiddenPair',
+      'nakedTriple',
+      'pointingPairs',
+      'pointingTriples',
+      'simpleColoring',
+    ],
+  },
+  expert: {
+    minClues: 22,
+    maxClues: 26,
+    allowedTechniques: [
+      'xWing',
+      'swordfish',
+      'multiColoring',
+      'lockedCandidates',
+      'pairsTriples',
+      'singles',
+    ],
+  },
+  fiendish: {
+    minClues: 20,
+    maxClues: 24,
+    allowedTechniques: ['xyWing', 'xyzWing', 'forcingChains', 'alternatingChains'],
+  },
+  ultimate: {
+    minClues: 17,
+    maxClues: 22,
+    allowedTechniques: ['nishio', 'uniqueness', 'longChains', 'advancedColoring'],
+  },
+};
+
+export function pickTargetCluesForLevel(seed: string, level: UltimateLevel): number {
+  const { minClues, maxClues } = LEVEL_RECIPES[level];
+  const rng = createRng(hashStringToSeed(`${seed}#lvl#${level}#target`));
+  const span = Math.max(0, maxClues - minClues);
+  const offset = Math.floor(rng() * Math.min(3, span + 1));
+  return Math.max(minClues, Math.min(maxClues, maxClues - offset));
+}


### PR DESCRIPTION
Implements Issue #400: adds level recipes and integrates a per-level generator path targeting clue windows with symmetric masks. Includes unit tests.\n\n- New: app/game/engine/levels.ts\n- Update: app/game/engine/generator.ts (level option)\n- Tests: __tests__/game/levels.generator.test.ts\n\nCI: Node 20.x; passes locally with npm run ci.