### PR TITLE
feat(solver): level-gated strategies and tests (Issue #401)

### DIFF
--- a/__tests__/game/solver.levels.test.ts
+++ b/__tests__/game/solver.levels.test.ts
@@ -1,0 +1,36 @@
+import { initializeGame } from '../../app/game/state';
+import { solveBoardByLevel, techniquesForLevel } from '../../app/game/engine/solver.levels';
+import type { Digit } from '../../app/game/types';
+
+function givensFromString(rows: string[]): { row: number; col: number; value: Digit }[] {
+  const givens: { row: number; col: number; value: Digit }[] = [];
+  rows.forEach((line, r) => {
+    line.split('').forEach((ch, c) => {
+      if (/[1-9]/.test(ch)) givens.push({ row: r, col: c, value: Number(ch) as Digit });
+    });
+  });
+  return givens;
+}
+
+describe('solver level gating', () => {
+  it('Novice uses singles-only techniques', () => {
+    const rows = [
+      '53..7....',
+      '6..195...',
+      '.98....6.',
+      '8...6...3',
+      '4..8.3..1',
+      '7...2...6',
+      '.6....28.',
+      '...419..5',
+      '....8..79',
+    ];
+    const givens = givensFromString(rows);
+    const game = initializeGame(givens, { difficulty: 'easy', maxLives: 3 });
+    const allowed = techniquesForLevel('novice');
+    expect(allowed).toEqual(['nakedSingle', 'hiddenSingle']);
+    const { steps } = solveBoardByLevel(game.board, 'novice');
+    const used = Array.from(new Set(steps.map((s) => s.technique)));
+    for (const t of used) expect(allowed).toContain(t);
+  });
+});

--- a/app/game/engine/solver.levels.ts
+++ b/app/game/engine/solver.levels.ts
@@ -1,0 +1,16 @@
+import type { Board } from '../types';
+import type { UltimateLevel } from './levels';
+import { LEVEL_RECIPES } from './levels';
+import { solveWithStrategies, type Technique } from './strategy';
+
+export function techniquesForLevel(level: UltimateLevel): Technique[] {
+  const recipe = LEVEL_RECIPES[level];
+  // Narrow to techniques implemented in strategy.ts for now
+  const known: Technique[] = ['nakedSingle', 'hiddenSingle'];
+  return known.filter((t) => recipe.allowedTechniques.includes(t));
+}
+
+export function solveBoardByLevel(board: Board, level: UltimateLevel) {
+  const techniques = techniquesForLevel(level);
+  return solveWithStrategies(board, techniques);
+}


### PR DESCRIPTION
Implements Issue #401: introduces level-gated solver wrapper and tests.\n\n- New: app/game/engine/solver.levels.ts\n- Tests: __tests__/game/solver.levels.test.ts\n- Minor: expose Technique type for gating\n\nCI passes locally.