### PR TITLE
feat(daily): integrate Ultimate levels into daily generation (Issue #403)

### DIFF
--- a/__tests__/game/daily.levels.test.ts
+++ b/__tests__/game/daily.levels.test.ts
@@ -1,0 +1,21 @@
+import { createDailySeed, formatDailySeed, generateDailyPuzzle } from '../../app/game/daily';
+
+describe('Daily with Ultimate levels', () => {
+  it('seed includes legacy difficulty and separate level is present', () => {
+    const date = new Date(Date.UTC(2025, 1, 3));
+    const seed = createDailySeed(date);
+    const s = formatDailySeed(seed);
+    expect(s).toMatch(/^\d{8}-[A-Z]-/);
+    expect(seed).toHaveProperty('level');
+    expect(['novice', 'skilled', 'advanced', 'expert', 'fiendish', 'ultimate']).toContain(
+      seed.level,
+    );
+  });
+
+  it('generateDailyPuzzle uses level path', () => {
+    const date = new Date(Date.UTC(2025, 1, 4));
+    const p = generateDailyPuzzle(date);
+    expect(p.givens.length).toBeGreaterThan(0);
+    expect(Array.isArray(p.solution)).toBe(true);
+  });
+});

--- a/app/game/daily/index.ts
+++ b/app/game/daily/index.ts
@@ -1,10 +1,12 @@
 import type { Difficulty } from '../types';
+import type { UltimateLevel } from '../engine/levels';
 import { generatePuzzle } from '../engine/generator';
 
 export type DailySeed = {
   utcDate: string; // YYYYMMDD
   patternId: string; // single uppercase letter A-Z
-  difficulty: Difficulty; // lowercase tier per app/game/types
+  difficulty: Difficulty; // legacy tier used for seed format & lives mapping
+  level: UltimateLevel; // Ultimate Sudoku level displayed in UI
 };
 
 export function createDailySeed(date: Date): DailySeed {
@@ -17,8 +19,9 @@ export function createDailySeed(date: Date): DailySeed {
   const week1Monday = new Date(jan4.getTime() - ((jan4.getUTCDay() + 6) % 7) * 86400000);
   const weekIndex = Math.floor((date.getTime() - week1Monday.getTime()) / (7 * 86400000));
   const patternId = String.fromCharCode('A'.charCodeAt(0) + (weekIndex % 26));
+  const level = levelForDate(date);
   const difficulty = difficultyForDate(date);
-  return { utcDate, patternId, difficulty };
+  return { utcDate, patternId, difficulty, level };
 }
 
 export function formatDailySeed(seed: DailySeed): string {
@@ -33,10 +36,42 @@ export function difficultyForDate(date: Date): Difficulty {
   return tiers[((weekIndex % tiers.length) + tiers.length) % tiers.length]!;
 }
 
+export function levelForDate(date: Date): UltimateLevel {
+  const levels: UltimateLevel[] = [
+    'novice',
+    'skilled',
+    'advanced',
+    'expert',
+    'fiendish',
+    'ultimate',
+  ];
+  const start = Date.UTC(2025, 0, 6); // Monday baseline for rotation
+  const weekIndex = Math.floor((date.getTime() - start) / (7 * 86400000));
+  return levels[((weekIndex % levels.length) + levels.length) % levels.length]!;
+}
+
+export function mapLevelToDifficulty(level: UltimateLevel): Difficulty {
+  switch (level) {
+    case 'novice':
+      return 'easy';
+    case 'skilled':
+      return 'medium';
+    case 'advanced':
+      return 'hard';
+    case 'expert':
+      return 'expert';
+    case 'fiendish':
+      return 'master';
+    case 'ultimate':
+      return 'extreme';
+  }
+}
+
 export function generateDailyPuzzle(date: Date) {
   const seed = createDailySeed(date);
   const seedString = formatDailySeed(seed);
-  return generatePuzzle({ seed: seedString, difficulty: seed.difficulty });
+  // Use Ultimate level path for generation while keeping legacy difficulty for seed stability
+  return generatePuzzle({ seed: seedString, level: seed.level });
 }
 
 // Screen component for Daily mode


### PR DESCRIPTION
Implements Issue #403: daily uses Ultimate level rotation and generator path, while preserving seed format and lives mapping. Adds tests.\n\n- Update: app/game/daily/index.ts (level fields + generate with level)\n- Tests: __tests__/game/daily.levels.test.ts\n\nCI passes locally.