### PR TITLE
feat(engine): variants scaffold and generator hook (Issue #406)

### DIFF
--- a/__tests__/game/variants.scaffold.test.ts
+++ b/__tests__/game/variants.scaffold.test.ts
@@ -1,0 +1,14 @@
+import {
+  applyVariantsMask,
+  validateVariants,
+  DEFAULT_VARIANTS,
+} from '../../app/game/engine/variants';
+
+describe('variants scaffold', () => {
+  it('no-op applyVariantsMask and validate true', () => {
+    const grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    const masked = applyVariantsMask(grid, DEFAULT_VARIANTS);
+    expect(masked).toHaveLength(9);
+    expect(validateVariants(masked, DEFAULT_VARIANTS)).toBe(true);
+  });
+});

--- a/app/game/engine/generator.ts
+++ b/app/game/engine/generator.ts
@@ -3,6 +3,8 @@ import type { UltimateLevel } from './levels';
 import { pickTargetCluesForLevel } from './levels';
 import { createRng, hashStringToSeed, shuffled } from './random';
 import { cloneGrid, countSolutions } from './solver';
+import type { VariantsConfig } from './variants';
+import { DEFAULT_VARIANTS, validateVariants } from './variants';
 import { pickTargetClues, generateMask, symmetryModes } from './masks';
 
 export type GenerateOptions = {
@@ -10,6 +12,7 @@ export type GenerateOptions = {
   difficulty?: Difficulty; // if provided, aim to meet clue thresholds fast
   minClues?: number; // legacy/override when uniqueness mode used
   level?: UltimateLevel; // new Ultimate levels API
+  variants?: VariantsConfig; // optional variants scaffold
 };
 
 export type GeneratedPuzzle = {
@@ -56,7 +59,7 @@ function generateSolvedGrid(seed: string): (Digit | null)[][] {
 }
 
 export function generatePuzzle(options: GenerateOptions): GeneratedPuzzle {
-  const { seed, difficulty, minClues, level } = options;
+  const { seed, difficulty, minClues, level, variants = DEFAULT_VARIANTS } = options;
 
   // Always compute a solved grid quickly
   const solution = cloneGrid(generateSolvedGrid(seed));
@@ -81,6 +84,10 @@ export function generatePuzzle(options: GenerateOptions): GeneratedPuzzle {
           givens.push({ row: r, col: c, value: solution[r]![c]! });
         }
       }
+    }
+    // Variants validation (scaffold only)
+    if (!validateVariants(solution, variants)) {
+      // If invalid under variants, retry by falling back to uniqueness mode later
     }
     return { givens, solution };
   }

--- a/app/game/engine/variants.ts
+++ b/app/game/engine/variants.ts
@@ -1,0 +1,39 @@
+import type { Digit } from '../types';
+
+export type VariantName =
+  | 'none'
+  | 'diagonal' // Sudoku X
+  | 'killer' // cages sum
+  | 'thermo' // thermometer increasing
+  | 'oddEven' // parity constraints
+  | 'extraRegion'; // extra 3x3 region or irregular
+
+export type VariantRule = {
+  name: VariantName;
+  enabled: boolean;
+  // Minimal payloads to be elaborated in future issues
+  data?: unknown;
+};
+
+export type VariantsConfig = {
+  rules: VariantRule[];
+};
+
+export const DEFAULT_VARIANTS: VariantsConfig = {
+  rules: [{ name: 'none', enabled: true }],
+};
+
+export type Grid = (Digit | null)[][];
+
+export function applyVariantsMask(grid: Grid, _variants: VariantsConfig): Grid {
+  // Scaffold: no-op until variants are implemented
+  void _variants;
+  return grid.map((row) => row.slice());
+}
+
+export function validateVariants(grid: Grid, _variants: VariantsConfig): boolean {
+  // Scaffold: always true for now; future work will enforce constraints
+  void _variants;
+  void grid;
+  return true;
+}


### PR DESCRIPTION
Implements Issue #406: adds a variants framework scaffold and integrates optional variants into the generator API (no-op for now). Includes a minimal test.\n\n- New: app/game/engine/variants.ts\n- Update: app/game/engine/generator.ts (variants option)\n- Tests: __tests__/game/variants.scaffold.test.ts