### PR TITLE
feat(settings/engine): timedChallenge + illusion scaffold (Issue #407)

### DIFF
--- a/__tests__/game/illusion.scaffold.test.ts
+++ b/__tests__/game/illusion.scaffold.test.ts
@@ -1,0 +1,10 @@
+import { analyzeIllusions } from '../../app/game/engine/illusion';
+
+describe('illusion detection scaffold', () => {
+  it('reports metrics without failing', () => {
+    const grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    const report = analyzeIllusions(grid);
+    expect(report.nishioCandidates).toBe(81);
+    expect(typeof report.hasContradictionSetup).toBe('boolean');
+  });
+});

--- a/__tests__/services/settings.conflicts.test.ts
+++ b/__tests__/services/settings.conflicts.test.ts
@@ -20,6 +20,7 @@ describe('settings conflict detection (#52)', () => {
         haptics: true,
         teachingPrompts: true,
         hintPathMode: 'off' as const,
+        timedChallenge: 'off' as const,
         theme: 'system' as const,
         accentColor: '#22c55e',
         gridSize: 1,

--- a/__tests__/services/settings.timed.test.ts
+++ b/__tests__/services/settings.timed.test.ts
@@ -1,0 +1,10 @@
+import { loadSettings, updateSettings } from '../../app/services/settings';
+
+describe('timed challenge setting', () => {
+  it('defaults to off and can be toggled on', async () => {
+    const s = await loadSettings();
+    expect(s.values.timedChallenge).toBe('off');
+    const next = await updateSettings('timedChallenge', 'on');
+    expect(next.values.timedChallenge).toBe('on');
+  });
+});

--- a/app/game/engine/illusion.ts
+++ b/app/game/engine/illusion.ts
@@ -1,0 +1,20 @@
+import type { Digit } from '../types';
+
+export type IllusionReport = {
+  hasContradictionSetup: boolean;
+  nishioCandidates: number;
+};
+
+export function analyzeIllusions(grid: (Digit | null)[][]): IllusionReport {
+  // Scaffold detection: metrics only
+  let nishioCandidates = 0;
+  for (let r = 0; r < 9; r++) {
+    for (let c = 0; c < 9; c++) {
+      if (grid[r]![c] == null) nishioCandidates++;
+    }
+  }
+  return {
+    hasContradictionSetup: nishioCandidates > 60,
+    nishioCandidates,
+  };
+}

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -13,6 +13,7 @@ export type SettingsValues = {
   haptics: boolean;
   teachingPrompts: boolean; // Novice level prompts
   hintPathMode: 'off' | 'skilled'; // Skilled hint path influence
+  timedChallenge: 'off' | 'on';
   theme: 'system' | 'light' | 'dark';
   accentColor: string;
   gridSize: number; // 0..2 small/medium/large
@@ -40,6 +41,7 @@ const DEFAULT_SETTINGS: SettingsData = {
     haptics: true,
     teachingPrompts: true,
     hintPathMode: 'off',
+    timedChallenge: 'off',
     theme: 'system',
     accentColor: '#22c55e',
     gridSize: 1,


### PR DESCRIPTION
Implements Issue #407: adds a timedChallenge setting and an illusion/contradiction detection scaffold with tests.\n\n- Update: app/services/settings.ts (timedChallenge defaults)\n- New: app/game/engine/illusion.ts (scaffold)\n- Tests: __tests__/services/settings.timed.test.ts, __tests__/game/illusion.scaffold.test.ts\n\nCI passes locally.