### PR TITLE
feat(ui): haptics on placement and error (#416)

### DIFF
--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -23,6 +23,7 @@ import { generatePuzzle } from './game/engine/generator';
 import type { UltimateLevel } from './game/engine/levels';
 import { FIXED_EASY_SEED, seedToGivens } from './game/fixtures';
 import { recordResult } from './services/stats';
+import { hapticError, hapticSuccess } from './services/haptics';
 
 type Preferences = { lastDifficulty?: Difficulty };
 const DIFFICULTIES: Difficulty[] = ['easy', 'medium', 'hard', 'expert', 'master', 'extreme'];
@@ -421,8 +422,8 @@ export default function ClassicScreen() {
             // ignore
           }
           if (lockedDigit != null) {
-            setGame((prev) =>
-              notesMode
+            setGame((prev) => {
+              const next = notesMode
                 ? applyAction(prev, {
                     type: 'note',
                     row: r,
@@ -430,8 +431,21 @@ export default function ClassicScreen() {
                     value: lockedDigit,
                     present: true,
                   })
-                : applyAction(prev, { type: 'place', row: r, col: c, value: lockedDigit }),
-            );
+                : applyAction(prev, { type: 'place', row: r, col: c, value: lockedDigit });
+              try {
+                if (!notesMode) {
+                  const beforeLives = prev.livesRemaining;
+                  const afterLives = next.livesRemaining;
+                  if (afterLives < beforeLives) void hapticError();
+                  else void hapticSuccess();
+                } else {
+                  void hapticSuccess();
+                }
+              } catch {
+                void 0;
+              }
+              return next;
+            });
           }
         }}
       />
@@ -442,8 +456,8 @@ export default function ClassicScreen() {
         onDigit={(d) => {
           if (!selected) return;
           const value = lockedDigit ?? d;
-          setGame((prev) =>
-            notesMode
+          setGame((prev) => {
+            const next = notesMode
               ? applyAction(prev, {
                   type: 'note',
                   row: selected.row,
@@ -451,8 +465,21 @@ export default function ClassicScreen() {
                   value,
                   present: true,
                 })
-              : applyAction(prev, { type: 'place', row: selected.row, col: selected.col, value }),
-          );
+              : applyAction(prev, { type: 'place', row: selected.row, col: selected.col, value });
+            try {
+              if (!notesMode) {
+                const beforeLives = prev.livesRemaining;
+                const afterLives = next.livesRemaining;
+                if (afterLives < beforeLives) void hapticError();
+                else void hapticSuccess();
+              } else {
+                void hapticSuccess();
+              }
+            } catch {
+              void 0;
+            }
+            return next;
+          });
         }}
         onToggleLock={(d) => setLockedDigit((prev) => (prev === d ? null : d))}
       />

--- a/app/components/GameScreenBase.tsx
+++ b/app/components/GameScreenBase.tsx
@@ -17,6 +17,7 @@ import type { Digit, Difficulty, GameAction } from '../game/types';
 import { isSolved } from '../game/rules';
 import { saveProgress, loadProgress } from '../services/storage';
 import { loadSettings } from '../services/settings';
+import { hapticError, hapticSuccess } from '../services/haptics';
 import { MaterialIcons } from '@expo/vector-icons';
 
 export type BasePuzzle = {
@@ -396,8 +397,8 @@ export default function GameScreenBase({
             // ignore out-of-bounds or unexpected access
           }
           if (lockedDigit != null) {
-            setGame((prev) =>
-              notesMode
+            setGame((prev) => {
+              const next = notesMode
                 ? applyAction(prev, {
                     type: 'note',
                     row: r,
@@ -405,8 +406,22 @@ export default function GameScreenBase({
                     value: lockedDigit,
                     present: true,
                   })
-                : applyAction(prev, { type: 'place', row: r, col: c, value: lockedDigit }),
-            );
+                : applyAction(prev, { type: 'place', row: r, col: c, value: lockedDigit });
+              try {
+                // Fire light success haptic on valid place; error when lives decreased
+                if (!notesMode) {
+                  const beforeLives = prev.livesRemaining;
+                  const afterLives = next.livesRemaining;
+                  if (afterLives < beforeLives) void hapticError();
+                  else void hapticSuccess();
+                } else {
+                  void hapticSuccess();
+                }
+              } catch {
+                // ignore
+              }
+              return next;
+            });
           }
         }}
       />
@@ -418,8 +433,8 @@ export default function GameScreenBase({
         onDigit={(d) => {
           if (!selected) return;
           const value = lockedDigit ?? d;
-          setGame((prev) =>
-            notesMode
+          setGame((prev) => {
+            const next = notesMode
               ? applyAction(prev, {
                   type: 'note',
                   row: selected.row,
@@ -427,8 +442,21 @@ export default function GameScreenBase({
                   value,
                   present: true,
                 })
-              : applyAction(prev, { type: 'place', row: selected.row, col: selected.col, value }),
-          );
+              : applyAction(prev, { type: 'place', row: selected.row, col: selected.col, value });
+            try {
+              if (!notesMode) {
+                const beforeLives = prev.livesRemaining;
+                const afterLives = next.livesRemaining;
+                if (afterLives < beforeLives) void hapticError();
+                else void hapticSuccess();
+              } else {
+                void hapticSuccess();
+              }
+            } catch {
+              // ignore
+            }
+            return next;
+          });
         }}
         onToggleLock={(d) => setLockedDigit((prev) => (prev === d ? null : d))}
       />

--- a/app/services/haptics.ts
+++ b/app/services/haptics.ts
@@ -1,0 +1,33 @@
+import { Platform } from 'react-native';
+
+// Dynamically require to avoid runtime issues in non-native/test environments
+
+let Haptics: undefined | typeof import('expo-haptics');
+try {
+  Haptics = require('expo-haptics');
+} catch {
+  Haptics = undefined;
+}
+
+function isSupportedEnvironment(): boolean {
+  // Disable on web and when module is unavailable (e.g., tests)
+  return Platform.OS !== 'web' && !!Haptics;
+}
+
+export async function hapticSuccess(): Promise<void> {
+  try {
+    if (!isSupportedEnvironment() || !Haptics) return;
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  } catch {
+    // no-op
+  }
+}
+
+export async function hapticError(): Promise<void> {
+  try {
+    if (!isSupportedEnvironment() || !Haptics) return;
+    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+  } catch {
+    // no-op
+  }
+}


### PR DESCRIPTION
Implements #416.\n- Adds app/services/haptics.ts safe wrapper\n- Fires success haptic on valid place and notes\n- Fires error haptic when a life is lost\n\nAll tests and build pass locally (npm run ci).