### PR TITLE
feat(stats): by-difficulty table and recent daily histogram (#417)

### DIFF
--- a/app/stats.screen.tsx
+++ b/app/stats.screen.tsx
@@ -51,6 +51,32 @@ export default function StatsScreen() {
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
+  const difficulties: Array<keyof StatsData['bestTimeByDifficulty']> = [
+    'easy',
+    'medium',
+    'hard',
+    'expert',
+    'master',
+    'extreme',
+  ];
+
+  // Build a simple histogram of recent daily completion times (wins only)
+  const buckets = [
+    { label: '0–2m', max: 120 },
+    { label: '2–5m', max: 300 },
+    { label: '5–10m', max: 600 },
+    { label: '10–20m', max: 1200 },
+    { label: '20m+', max: Infinity },
+  ];
+  const histCounts = buckets.map(() => 0);
+  for (const r of stats.recentDailyResults) {
+    if (r.result !== 'win') continue;
+    const secs = r.seconds;
+    const idx = buckets.findIndex((b) => secs <= b.max);
+    if (idx >= 0) histCounts[idx]! += 1;
+  }
+  const maxCount = Math.max(1, ...histCounts);
+
   const winRate =
     stats.totals.played > 0 ? ((stats.totals.wins / stats.totals.played) * 100).toFixed(1) : '0.0';
 
@@ -111,25 +137,71 @@ export default function StatsScreen() {
             borderRadius: 8,
           }}
         >
-          {Object.entries(stats.bestTimeByDifficulty).length > 0 ? (
-            Object.entries(stats.bestTimeByDifficulty).map(([difficulty, time]) => (
-              <View
-                key={difficulty}
-                style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}
-              >
-                <Text style={{ color: theme.foreground, textTransform: 'capitalize' }}>
-                  {difficulty}:
-                </Text>
-                <Text style={{ color: theme.foreground, fontWeight: '600' }}>
-                  {formatTime(time)}
+          {difficulties.map((d) => (
+            <View
+              key={d}
+              style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 }}
+            >
+              <Text style={{ color: theme.foreground, textTransform: 'capitalize' }}>{d}:</Text>
+              <Text style={{ color: theme.foreground, fontWeight: '600' }}>
+                {typeof stats.bestTimeByDifficulty[d] === 'number'
+                  ? formatTime(stats.bestTimeByDifficulty[d] as number)
+                  : '—'}
+              </Text>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* Time Distribution (Recent Daily Wins) */}
+      <View style={{ marginBottom: 24 }}>
+        <Text
+          style={{ fontSize: 18, fontWeight: '600', marginBottom: 12, color: theme.foreground }}
+        >
+          Time Distribution (Recent Daily Wins)
+        </Text>
+        <View
+          style={{
+            backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
+            padding: 16,
+            borderRadius: 8,
+            gap: 8,
+          }}
+        >
+          {buckets.map((b, i) => {
+            const count = histCounts[i]!;
+            const widthPct = Math.max(6, Math.round((count / maxCount) * 100));
+            return (
+              <View key={b.label} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <Text style={{ width: 64, color: theme.foreground }}>{b.label}</Text>
+                <View
+                  style={{
+                    flex: 1,
+                    height: 12,
+                    backgroundColor: theme.isDark ? '#111827' : '#e5e7eb',
+                    borderRadius: 6,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <View
+                    style={{
+                      width: `${widthPct}%`,
+                      height: '100%',
+                      backgroundColor: theme.isDark ? '#60a5fa' : '#2563eb',
+                    }}
+                  />
+                </View>
+                <Text style={{ color: theme.foreground, width: 24, textAlign: 'right' }}>
+                  {count}
                 </Text>
               </View>
-            ))
-          ) : (
+            );
+          })}
+          {histCounts.every((c) => c === 0) ? (
             <Text style={{ color: theme.foreground, opacity: 0.7, fontStyle: 'italic' }}>
-              No best times recorded yet
+              No recent daily wins to chart
             </Text>
-          )}
+          ) : null}
         </View>
       </View>
 


### PR DESCRIPTION
Implements #417.\n- Adds explicit by-difficulty best times table (including missing entries as —)\n- Adds recent daily wins time histogram (0–2m, 2–5m, 5–10m, 10–20m, 20m+)\n\nAll checks pass locally (npm run ci).