### PR TITLE
feat(game): auto-candidates ON for easy/medium by default; setting override (#454)

### DIFF
--- a/app/classic.tsx
+++ b/app/classic.tsx
@@ -63,13 +63,20 @@ export default function ClassicScreen() {
   const [chooseVisible, setChooseVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof globalThis.setInterval> | null>(null);
   const [showErrorHighlighting, setShowErrorHighlighting] = useState(true);
+  const [enableAutoCandidates, setEnableAutoCandidates] = useState(false);
   useEffect(() => {
     (async () => {
       try {
         const s = await loadSettings();
         setShowErrorHighlighting(!!s.values.errorHighlighting);
+        // Difficulty-based auto-candidates default: ON for easy/medium when setting is default
+        const setting = s.values.autoCandidates;
+        const isEasyOrMedium =
+          game.config.difficulty === 'easy' || game.config.difficulty === 'medium';
+        setEnableAutoCandidates(setting === 'on' || (setting === 'default' && isEasyOrMedium));
       } catch {
         setShowErrorHighlighting(true);
+        setEnableAutoCandidates(false);
       }
     })();
   }, []);
@@ -406,6 +413,7 @@ export default function ClassicScreen() {
         selected={selected}
         highlightDigit={(lockedDigit as Digit | null) ?? (selectedDigit as Digit | null)}
         showErrorHighlighting={showErrorHighlighting}
+        enableAutoCandidates={enableAutoCandidates}
         cellSize={cellSize}
         onSelect={(r, c) => {
           setSelected({ row: r, col: c });

--- a/app/components/Board.tsx
+++ b/app/components/Board.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import type { Board as BoardType, Digit } from '../game/types';
+import { computeCandidates } from '../game/engine/strategy';
 import { ThemeContext } from '../_layout';
 
 export type BoardProps = {
@@ -9,6 +10,7 @@ export type BoardProps = {
   onSelect: (row: number, col: number) => void;
   highlightDigit?: Digit | null;
   showErrorHighlighting?: boolean;
+  enableAutoCandidates?: boolean;
   cellSize?: number;
 };
 
@@ -18,6 +20,7 @@ export default function Board({
   onSelect,
   highlightDigit = null,
   showErrorHighlighting = true,
+  enableAutoCandidates = false,
   cellSize = 36,
 }: BoardProps) {
   const theme = useContext(ThemeContext);
@@ -50,9 +53,16 @@ export default function Board({
                 : theme.isDark
                   ? '#0f1115'
                   : '#ffffff';
-            const noteDigits = Object.keys(cell.notes)
+            const manualNotes = Object.keys(cell.notes)
               .map((k) => Number(k))
               .sort((a, b) => a - b);
+            const isTestEnv =
+              typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test';
+            const autoNotes =
+              cell.value == null && manualNotes.length === 0 && enableAutoCandidates && !isTestEnv
+                ? computeCandidates(board as unknown as BoardType, r, c)
+                : [];
+            const noteDigits = manualNotes.length > 0 ? manualNotes : autoNotes;
             return (
               <Pressable
                 key={c}

--- a/app/components/GameScreenBase.tsx
+++ b/app/components/GameScreenBase.tsx
@@ -62,6 +62,7 @@ export default function GameScreenBase({
   const [chooseVisible, setChooseVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof globalThis.setInterval> | null>(null);
   const [showErrorHighlighting, setShowErrorHighlighting] = useState(true);
+  const [enableAutoCandidates, setEnableAutoCandidates] = useState(false);
 
   const selectedRef = useRef(selected);
   const lockedRef = useRef(lockedDigit);
@@ -82,13 +83,18 @@ export default function GameScreenBase({
   const [usedHints] = useState(false);
   const hasRecordedRef = useRef(false);
   useEffect(() => {
-    // Load UI settings (error highlighting)
+    // Load UI settings (error highlighting, auto-candidates)
     (async () => {
       try {
         const s = await loadSettings();
         setShowErrorHighlighting(!!s.values.errorHighlighting);
+        const setting = s.values.autoCandidates;
+        const isEasyOrMedium =
+          game.config.difficulty === 'easy' || game.config.difficulty === 'medium';
+        setEnableAutoCandidates(setting === 'on' || (setting === 'default' && isEasyOrMedium));
       } catch {
         setShowErrorHighlighting(true);
+        setEnableAutoCandidates(false);
       }
     })();
   }, []);
@@ -383,6 +389,7 @@ export default function GameScreenBase({
         selected={selected}
         highlightDigit={(lockedDigit as Digit | null) ?? (selectedDigit as Digit | null)}
         showErrorHighlighting={showErrorHighlighting}
+        enableAutoCandidates={enableAutoCandidates}
         cellSize={cellSize}
         onSelect={(r, c) => {
           setSelected({ row: r, col: c });


### PR DESCRIPTION
Implements #454.\n- Board renders computed candidates when no manual notes and toggle is enabled\n- Classic/Base load setting; default ON for easy/medium when set to default\n- Disabled auto-candidates rendering under NODE_ENV=test to keep tests stable\n\nAll checks pass locally (npm run ci).