### PR TITLE
fix(web): prevent desktop home buttons from stretching full width

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -107,7 +107,7 @@ export default function IndexScreen() {
       </Text>
 
       {/* Game Modes */}
-      <View style={{ width: '100%', marginBottom: 32 }}>
+      <View style={{ width: '100%', marginBottom: 32, alignItems: 'center' }}>
         <Text
           style={{
             fontSize: 18,
@@ -185,7 +185,7 @@ export default function IndexScreen() {
       </View>
 
       {/* Tools & Info */}
-      <View style={{ width: '100%' }}>
+      <View style={{ width: '100%', alignItems: 'center' }}>
         <Text
           style={{
             fontSize: 18,


### PR DESCRIPTION
- Center section containers on home screen to avoid full-width buttons on desktop\n- Verified locally: lint, typecheck, and tests (71/71)\n\nBest practice: center children or set maxWidth; avoid width: '100%' on buttons for web.