### PR TITLE
fix(web): normalize home button widths and vertical alignment

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -130,9 +130,11 @@ export default function IndexScreen() {
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
+            minHeight: 96,
             borderRadius: 12,
             marginBottom: 12,
             alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.foreground }}>
@@ -153,9 +155,11 @@ export default function IndexScreen() {
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
+            minHeight: 96,
             borderRadius: 12,
             marginBottom: 12,
             alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.foreground }}>
@@ -176,9 +180,11 @@ export default function IndexScreen() {
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
+            minHeight: 96,
             borderRadius: 12,
             marginBottom: 12,
             alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.foreground }}>
@@ -214,9 +220,11 @@ export default function IndexScreen() {
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
+            minHeight: 96,
             borderRadius: 12,
             marginBottom: 12,
             alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.foreground }}>
@@ -237,9 +245,11 @@ export default function IndexScreen() {
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
+            minHeight: 96,
             borderRadius: 12,
             marginBottom: 12,
             alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <Text style={{ fontSize: 18, fontWeight: '600', color: theme.foreground }}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -107,7 +107,7 @@ export default function IndexScreen() {
       </Text>
 
       {/* Game Modes */}
-      <View style={{ width: '100%', marginBottom: 32 }}>
+      <View style={{ width: '100%', marginBottom: 32, alignItems: 'center' }}>
         <Text
           style={{
             fontSize: 18,
@@ -185,7 +185,7 @@ export default function IndexScreen() {
       </View>
 
       {/* Tools & Info */}
-      <View style={{ width: '100%' }}>
+      <View style={{ width: '100%', alignItems: 'center' }}>
         <Text
           style={{
             fontSize: 18,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -125,6 +125,8 @@ export default function IndexScreen() {
           accessibilityRole="button"
           accessibilityLabel="Go to Classic Sudoku"
           style={{
+            width: '100%',
+            maxWidth: 420,
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
@@ -146,6 +148,8 @@ export default function IndexScreen() {
           accessibilityRole="button"
           accessibilityLabel="Go to Daily Challenge"
           style={{
+            width: '100%',
+            maxWidth: 420,
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
@@ -167,6 +171,8 @@ export default function IndexScreen() {
           accessibilityRole="button"
           accessibilityLabel="Go to Daily Calendar"
           style={{
+            width: '100%',
+            maxWidth: 420,
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
@@ -203,6 +209,8 @@ export default function IndexScreen() {
           accessibilityRole="button"
           accessibilityLabel="View Game Statistics"
           style={{
+            width: '100%',
+            maxWidth: 420,
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
@@ -224,6 +232,8 @@ export default function IndexScreen() {
           accessibilityRole="button"
           accessibilityLabel="Go to Settings"
           style={{
+            width: '100%',
+            maxWidth: 420,
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,
@@ -245,6 +255,8 @@ export default function IndexScreen() {
           accessibilityRole="button"
           accessibilityLabel="Get Help and Information"
           style={{
+            width: '100%',
+            maxWidth: 420,
             backgroundColor: theme.isDark ? '#1f2937' : '#f3f4f6',
             paddingVertical: 16,
             paddingHorizontal: 20,


### PR DESCRIPTION
- Make home buttons consistent: width: '100%' + maxWidth: 420 + minHeight: 96\n- Keep buttons centered and avoid desktop full-width stretch\n- Verified locally: lint, typecheck, and tests (71/71)\n\nIf desired, we can tweak maxWidth/minHeight values in a follow-up.