### PR TITLE
docs(rules): accessibility rules (#424)

### DIFF
--- a/.cursor/rules/20-style-guide.md
+++ b/.cursor/rules/20-style-guide.md
@@ -19,6 +19,7 @@ Definition of Done:
 - Functional components with hooks only.
 - Keep components small and pure. Extract hooks for complex logic.
 - Accessibility: use accessible roles, labels, and test with screen readers.
+  See `25-accessibility.md` for RN and Web specifics (roles, labels, focus, modals, testing).
 
 # Imports and Structure
 

--- a/.cursor/rules/25-accessibility.md
+++ b/.cursor/rules/25-accessibility.md
@@ -1,0 +1,50 @@
+Rule: Accessibility (RN + Web)
+Applies to: app/**, app/components/**
+Use when: creating or updating UI
+Avoid: unlabeled controls, broken focus, keyboard traps
+Definition of Done:
+
+- Interactive elements have roles and labels
+- Keyboard and screen reader flows are testable
+- Modals and overlays manage focus correctly
+
+# Roles and Labels
+
+- React Native: set `accessibilityRole` (button, header, link) and `accessibilityLabel`.
+- Web: use semantic elements or ARIA (`role`, `aria-label`, `aria-labelledby`).
+- Provide `accessibilityHint` where the action isn’t obvious.
+
+# Keyboard and Focus
+
+- Ensure visible focus on Web; custom components must expose focus styles.
+- Trap focus inside modals; restore focus to opener when closing.
+- Support Escape/Back to dismiss overlays; prevent background scroll.
+
+# Modals and Overlays
+
+- Mark overlay containers with `accessibilityViewIsModal` (RN) and `role="dialog"` + `aria-modal="true"` (Web).
+- Provide a labeled title via `aria-labelledby` or set `accessibilityLabel`.
+
+# Lists and Virtualization
+
+- Use `accessibilityRole="list"` and `listitem` where applicable.
+- Announce dynamic updates with polite live regions on Web when needed.
+
+# Testing Patterns
+
+- Prefer queries by role and name: `getByRole('button', { name: /start/i })`.
+- Assert focus order with keyboard tabbing on Web; validate RN labels via Testing Library.
+- Include at least one accessibility assertion per new screen.
+
+# Always / Never
+
+- Always label icon-only buttons.
+- Always provide visible focus on Web.
+- Never rely solely on color to convey meaning.
+- Never block keyboard navigation.
+
+# Examples
+
+- Button
+  - RN: `<Pressable accessibilityRole="button" accessibilityLabel="Start new game" />`
+  - Web: `<button aria-label="Start new game" />`

--- a/.cursor/rules/50-devops.md
+++ b/.cursor/rules/50-devops.md
@@ -27,6 +27,8 @@ Definition of Done:
 
 - Standard: Changesets drives versioning and changelog. Base branch is `staging`. Use Node version from `engines.node` in `package.json` (repo standard: Node 20.x via Volta) when configuring CI.
 
+- Standard: Changesets drives versioning and changelog. Base branch is `staging`. Use Node version from `engines.node` in `package.json` (repo standard: Node 20.x via Volta) when configuring CI.
+
 # Environments
 
 - Keep staging mirror close to production config.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -51,6 +51,43 @@ module.exports = [
 		},
 	},
 	{
+		files: [
+			"app/*.screen.tsx",
+			"app/components/**/*.{ts,tsx}",
+		],
+		rules: {
+			"no-restricted-imports": [
+				"warn",
+				{
+					"paths": [
+						{
+							"name": "app/services/storage",
+							"message": "UI should not import storage directly; prefer a container/hook boundary."
+						},
+						{
+							"name": "app/services/supabase",
+							"message": "UI should not import Supabase/network directly; prefer a container/hook boundary."
+						},
+						{
+							"name": "app/services/sync",
+							"message": "UI should not import network sync directly; prefer a container/hook boundary."
+						}
+					],
+					"patterns": [
+						{
+							"group": [
+								"app/services/storage*",
+								"app/services/supabase*",
+								"app/services/sync*"
+							],
+							"message": "UI should not import storage/network services directly."
+						}
+					]
+				}
+			]
+		}
+	},
+	{
 		files: ["**/__tests__/**/*.{ts,tsx,js,jsx}", "jest.setup.ts"],
 		languageOptions: {
 			globals: {


### PR DESCRIPTION
Implements #424: Adds .cursor/rules/25-accessibility.md and links it from 20-style-guide.md. Local CI green.