### PR TITLE
docs(rules): Supabase engineering rules (#427)

### DIFF
--- a/.cursor/rules/70-supabase.md
+++ b/.cursor/rules/70-supabase.md
@@ -1,0 +1,54 @@
+# Supabase Engineering Rules (Issue #427)
+
+Applies to: app/**, scripts/**, CI
+Use when: accessing Supabase, adding envs, writing network tests, creating migrations
+Avoid: leaking secrets, bundling admin client in app, brittle network tests
+Definition of Done:
+
+- Env vars named consistently and read via a single module
+- Client creation is guarded and tree-shakeable; admin code never ships to app
+- Contract tests run against MSW/fakes; live calls only in dedicated E2E
+- Migrations follow naming/rollback conventions
+
+## Environment Naming & Access
+
+- Public client envs:
+  - `EXPO_PUBLIC_SUPABASE_URL`
+  - `EXPO_PUBLIC_SUPABASE_ANON_KEY`
+- Never read envs ad hoc across the codebase. Centralize access in `app/services/supabase.ts`.
+- In tests, if envs are missing, log a single warning and provide a safe no-op client.
+
+## Client Guards & Bundling
+
+- App bundle must only include the public client (no service role keys).
+- Guard client creation:
+  - Export a factory that returns a configured client when both URL and ANON are set.
+  - Otherwise return a stub with no-op methods used by tests.
+- Keep admin/service-role client usage in server-only scripts or CI utilities, never in app code.
+
+## Contract Tests & MSW
+
+- Prefer MSW handlers or fakes over live network calls in unit tests.
+- Model success, error, and edge cases; reset handlers between tests.
+- Keep a small number of CI smoke tests for serialization/shape using recorded fixtures.
+
+## Local Profiles
+
+- Document local profiles (e.g., `.env.development`, `.env.test`) and how to obtain URL/key.
+- Do not commit secrets. Use `.env*` in `.gitignore`; provide `.env.example` for required keys.
+
+## Migrations Conventions
+
+- Use descriptive, timestamped names (e.g., `20250905T1230_add_user_index.sql`).
+- Migrations must be idempotent or guard against double-apply when feasible.
+- Provide down/rollback where supported; document irreversible changes.
+
+## CI Expectations
+
+- Lint/type/tests must pass without live Supabase.
+- For any job needing live Supabase, run in a separate workflow with explicit secrets and safeguards.
+
+## References
+
+- Related: `40-security.md`, `50-devops.md`, `30-testing.md`
+- Issue: #427

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -12,6 +12,7 @@ When to use: as a starting point to find the right rule file.
 - 55-bundle-performance.md — Bundle and performance budgets, heavy-dep checklist
 - 60-prompts.md — Cursor task macros
 - epic-prompts.md — Epic automation and finalize prompts (consolidated)
+- 70-supabase.md — Supabase engineering rules (envs, client guards, tests, migrations)
 - 99-glossary.md — Project-specific terminology and definitions
 
 Conventions


### PR DESCRIPTION
Implements #427: Adds .cursor/rules/70-supabase.md (envs, client guards, MSW tests, migrations) and updates the rules index. Local CI green.