### PR TITLE
ci(lint): expand ESLint rules (#428)

### DIFF
--- a/.cursor/rules/70-supabase.md
+++ b/.cursor/rules/70-supabase.md
@@ -1,0 +1,54 @@
+# Supabase Engineering Rules (Issue #427)
+
+Applies to: app/**, scripts/**, CI
+Use when: accessing Supabase, adding envs, writing network tests, creating migrations
+Avoid: leaking secrets, bundling admin client in app, brittle network tests
+Definition of Done:
+
+- Env vars named consistently and read via a single module
+- Client creation is guarded and tree-shakeable; admin code never ships to app
+- Contract tests run against MSW/fakes; live calls only in dedicated E2E
+- Migrations follow naming/rollback conventions
+
+## Environment Naming & Access
+
+- Public client envs:
+  - `EXPO_PUBLIC_SUPABASE_URL`
+  - `EXPO_PUBLIC_SUPABASE_ANON_KEY`
+- Never read envs ad hoc across the codebase. Centralize access in `app/services/supabase.ts`.
+- In tests, if envs are missing, log a single warning and provide a safe no-op client.
+
+## Client Guards & Bundling
+
+- App bundle must only include the public client (no service role keys).
+- Guard client creation:
+  - Export a factory that returns a configured client when both URL and ANON are set.
+  - Otherwise return a stub with no-op methods used by tests.
+- Keep admin/service-role client usage in server-only scripts or CI utilities, never in app code.
+
+## Contract Tests & MSW
+
+- Prefer MSW handlers or fakes over live network calls in unit tests.
+- Model success, error, and edge cases; reset handlers between tests.
+- Keep a small number of CI smoke tests for serialization/shape using recorded fixtures.
+
+## Local Profiles
+
+- Document local profiles (e.g., `.env.development`, `.env.test`) and how to obtain URL/key.
+- Do not commit secrets. Use `.env*` in `.gitignore`; provide `.env.example` for required keys.
+
+## Migrations Conventions
+
+- Use descriptive, timestamped names (e.g., `20250905T1230_add_user_index.sql`).
+- Migrations must be idempotent or guard against double-apply when feasible.
+- Provide down/rollback where supported; document irreversible changes.
+
+## CI Expectations
+
+- Lint/type/tests must pass without live Supabase.
+- For any job needing live Supabase, run in a separate workflow with explicit secrets and safeguards.
+
+## References
+
+- Related: `40-security.md`, `50-devops.md`, `30-testing.md`
+- Issue: #427

--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -12,6 +12,7 @@ When to use: as a starting point to find the right rule file.
 - 55-bundle-performance.md — Bundle and performance budgets, heavy-dep checklist
 - 60-prompts.md — Cursor task macros
 - epic-prompts.md — Epic automation and finalize prompts (consolidated)
+- 70-supabase.md — Supabase engineering rules (envs, client guards, tests, migrations)
 - 99-glossary.md — Project-specific terminology and definitions
 
 Conventions

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -8,7 +8,7 @@ const prettier = require("eslint-config-prettier");
 
 module.exports = [
 	{
-		ignores: ["node_modules/**", "dist/**", "build/**", "web-build/**"],
+		ignores: ["node_modules/**", "dist/**", "build/**", "web-build/**", ".expo/**", "**/*.d.ts"],
 	},
 	js.configs.recommended,
 	{
@@ -37,6 +37,24 @@ module.exports = [
 		rules: {
 			...tsPlugin.configs.recommended.rules,
 			"@typescript-eslint/no-require-imports": "off",
+			"@typescript-eslint/consistent-type-imports": [
+				"warn",
+				{ "prefer": "type-imports", "fixStyle": "inline-type-imports" }
+			],
+			"@typescript-eslint/no-floating-promises": [
+				"warn",
+				{ "ignoreVoid": true, "ignoreIIFE": true }
+			],
+			"sort-imports": [
+				"warn",
+				{
+					"ignoreCase": true,
+					"ignoreDeclarationSort": false,
+					"ignoreMemberSort": false,
+					"allowSeparatedGroups": true
+				}
+			],
+			"no-console": ["error", { "allow": ["warn", "error"] }],
 			"no-restricted-imports": [
 				"error",
 				{
@@ -99,6 +117,9 @@ module.exports = [
 				jest: "readonly",
 			},
 		},
+		rules: {
+			"no-console": "off"
+		}
 	},
 	{
 		files: [

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -8,9 +8,18 @@ const prettier = require("eslint-config-prettier");
 
 module.exports = [
 	{
-		ignores: ["node_modules/**", "dist/**", "build/**", "web-build/**", ".expo/**", "**/*.d.ts"],
+		ignores: [
+			"node_modules/**",
+			"dist/**",
+			"build/**",
+			"web-build/**",
+			".expo/**",
+			"**/*.d.ts",
+		],
 	},
+
 	js.configs.recommended,
+
 	{
 		files: ["**/*.{ts,tsx}", "app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
 		languageOptions: {
@@ -39,35 +48,54 @@ module.exports = [
 			"@typescript-eslint/no-require-imports": "off",
 			"@typescript-eslint/consistent-type-imports": [
 				"warn",
-				{ "prefer": "type-imports", "fixStyle": "inline-type-imports" }
-			],
-			"@typescript-eslint/no-floating-promises": [
-				"warn",
-				{ "ignoreVoid": true, "ignoreIIFE": true }
+				{ prefer: "type-imports", fixStyle: "inline-type-imports" },
 			],
 			"sort-imports": [
 				"warn",
 				{
-					"ignoreCase": true,
-					"ignoreDeclarationSort": false,
-					"ignoreMemberSort": false,
-					"allowSeparatedGroups": true
-				}
+					ignoreCase: true,
+					ignoreDeclarationSort: false,
+					ignoreMemberSort: false,
+					allowSeparatedGroups: true,
+				},
 			],
-			"no-console": ["error", { "allow": ["warn", "error"] }],
+			"no-console": ["error", { allow: ["warn", "error"] }],
 			"no-restricted-imports": [
 				"error",
 				{
-					"patterns": [
+					patterns: [
 						{
-							"group": ["**/_game/**", "**/../_game/**", "**/../../_game/**"],
-							"message": "Do not import from app/_game; use app/game as the canonical module."
-						}
-					]
-				}
-			]
+							group: ["**/_game/**", "**/../_game/**", "**/../../_game/**"],
+							message:
+								"Do not import from app/_game; use app/game as the canonical module.",
+						},
+					],
+				},
+			],
 		},
 	},
+
+	// Typed linting for selected TS sources only
+	{
+		files: ["app/**/*.{ts,tsx}", "scripts/**/*.{ts,tsx}"],
+		languageOptions: {
+			parser: tsParser,
+			parserOptions: {
+				projectService: true,
+			},
+		},
+		plugins: {
+			"@typescript-eslint": tsPlugin,
+		},
+		rules: {
+			"@typescript-eslint/no-floating-promises": [
+				"warn",
+				{ ignoreVoid: true, ignoreIIFE: true },
+			],
+		},
+	},
+
+	// UI boundaries (warnings) for screens/components
 	{
 		files: [
 			"app/*.screen.tsx",
@@ -77,34 +105,40 @@ module.exports = [
 			"no-restricted-imports": [
 				"warn",
 				{
-					"paths": [
+					paths: [
 						{
-							"name": "app/services/storage",
-							"message": "UI should not import storage directly; prefer a container/hook boundary."
+							name: "app/services/storage",
+							message:
+								"UI should not import storage directly; prefer a container/hook boundary.",
 						},
 						{
-							"name": "app/services/supabase",
-							"message": "UI should not import Supabase/network directly; prefer a container/hook boundary."
+							name: "app/services/supabase",
+							message:
+								"UI should not import Supabase/network directly; prefer a container/hook boundary.",
 						},
 						{
-							"name": "app/services/sync",
-							"message": "UI should not import network sync directly; prefer a container/hook boundary."
-						}
+							name: "app/services/sync",
+							message:
+								"UI should not import network sync directly; prefer a container/hook boundary.",
+						},
 					],
-					"patterns": [
+					patterns: [
 						{
-							"group": [
+							group: [
 								"app/services/storage*",
 								"app/services/supabase*",
-								"app/services/sync*"
+								"app/services/sync*",
 							],
-							"message": "UI should not import storage/network services directly."
-						}
-					]
-				}
-			]
-		}
+							message:
+								"UI should not import storage/network services directly.",
+						},
+					],
+				},
+			],
+		},
 	},
+
+	// Tests
 	{
 		files: ["**/__tests__/**/*.{ts,tsx,js,jsx}", "jest.setup.ts"],
 		languageOptions: {
@@ -118,9 +152,11 @@ module.exports = [
 			},
 		},
 		rules: {
-			"no-console": "off"
-		}
+			"no-console": "off",
+		},
 	},
+
+	// Tooling/configs/scripts
 	{
 		files: [
 			"*.config.js",
@@ -143,6 +179,7 @@ module.exports = [
 			},
 		},
 	},
+
 	// Prettier should be last to disable conflicting rules
 	prettier,
 ];


### PR DESCRIPTION
Implements #428: adds consistent-type-imports, scoped no-floating-promises (typed), sort-imports, production no-console; disabled in tests. Excludes .expo/** and *.d.ts. Local CI green.